### PR TITLE
fix(creators): Avoid early error feedback from ENS resolving.

### DIFF
--- a/apps/main-landing/src/app/creators/page.tsx
+++ b/apps/main-landing/src/app/creators/page.tsx
@@ -63,7 +63,7 @@ export default function Donors() {
       chainsIds: ALL_CHAIN_IDS,
       tokensSymbols: UNIQUE_ALL_TOKEN_SYMBOLS,
     },
-    mode: 'onChange',
+    mode: 'onSubmit',
   });
   const [creatorName, chainsIds, tokensSymbols, address] = formMethods.watch([
     'name',
@@ -260,7 +260,7 @@ export default function Donors() {
                   required: 'Address is required',
                   validate: async (value) => {
                     try {
-                      if (value.includes('.')) {
+                      if (value.includes('.') && !value.endsWith('.')) {
                         const resolvedAddress =
                           await ethereumClient?.getEnsAddress({
                             name: normalize(value),


### PR DESCRIPTION
## Overview
Fixes early error returns when typing an ENS or address manually.

# How it was fixed
The validation method on the form (from react-hook-form) was changed from onChange to onSubmit, meaning every field of the form gets validated after clicking the "DONATION LINK" button (submitting the form).
There was also an extra check for typed ENS names ending with a dot '.' that awas added to avoid present errors on calling resolver on them.  

## Checklist
[x] I have tested the functionality
