### PR TITLE
fix: out of gas native donations

### DIFF
--- a/apps/main-landing/src/app/creators/donate/hooks/use-native-transaction.ts
+++ b/apps/main-landing/src/app/creators/donate/hooks/use-native-transaction.ts
@@ -47,6 +47,7 @@ export const useNativeTransaction = () => {
       const gas = await estimateGas(walletClient, {
         to: idrissTippingAddress,
         account,
+        value: tokensToSend,
         data: encodedData,
       }).catch((error) => {
         console.error('Error estimating gas:', error.message);


### PR DESCRIPTION
## Overview
Donating in native currency was failing with error `out of gas`, as seen in: https://optimistic.etherscan.io/tx/0xa5d0fecaab957847177514c085c03ea148febaf83e9652e51bb9b82d93adee4d

## How it was fixed
I had mistakenly avoided the value in the gas estimate before sending the transaction. Added it back in this commit.

## How to test
Send any native currency donation with any amount on any chain. It should work.