### PR TITLE
fix: refine scraping methods for warpcast after their structural changes

### DIFF
--- a/apps/extension/src/host/warpcast/scraper.ts
+++ b/apps/extension/src/host/warpcast/scraper.ts
@@ -42,7 +42,11 @@ export class Scraper {
 
     return posts
       .map((post) => {
-        const links = [...post.querySelectorAll('a.font-semibold.hover\\:underline[data-idrissid]')];
+        const links = [
+          ...post.querySelectorAll(
+            'a.font-semibold.hover:underline[data-idrissid]',
+          ),
+        ];
 
         const usernameLinkNode = links.length > 0 ? links[0] : undefined;
         const repostUsernameLinkNode = links.length > 1 ? links[1] : undefined;
@@ -439,7 +443,7 @@ export class Scraper {
     const link = Scraper.getMain()?.querySelector('nav div > span > a');
     const username = link?.getAttribute('href')?.replace('/', '');
     const userFullNameNode = link?.querySelector(':scope > span');
-    if (!username || !userFullNameNode?.parentElement || !userFullNameNode.parentElement.parentElement) {
+    if (!username || !userFullNameNode?.parentElement?.parentElement) {
       return;
     }
     const node = userFullNameNode.parentElement.parentElement;

--- a/apps/extension/src/host/warpcast/scraper.ts
+++ b/apps/extension/src/host/warpcast/scraper.ts
@@ -131,6 +131,7 @@ export class Scraper {
         const rect = userFullNameNode.getBoundingClientRect();
 
         const node = userFullNameNode.parentElement;
+        node.classList.remove('space-x-2');
         node.style.setProperty('display', 'flex', 'important');
         node.style.setProperty('align-items', 'center', 'important');
 
@@ -176,6 +177,7 @@ export class Scraper {
 
     const rect = userFullNameNode.getBoundingClientRect();
     const node = userFullNameNode.parentElement;
+    node.classList.remove('space-x-2');
     node.style.setProperty('display', 'inline-flex', 'important');
     node.style.setProperty('align-items', 'center', 'important');
 
@@ -230,8 +232,11 @@ export class Scraper {
           return;
         }
 
-        node.style.setProperty('display', 'inline-flex', 'important');
-        node.style.setProperty('align-items', 'center', 'important');
+        // skip applying inline-flex in the notifications tab, as it leads to squashed elements
+        if (!username.includes('notifications')) {
+          node.style.setProperty('display', 'inline-flex', 'important');
+          node.style.setProperty('align-items', 'center', 'important');
+        }
 
         return {
           node,
@@ -314,6 +319,7 @@ export class Scraper {
         const rect = userFullNameNode.getBoundingClientRect();
 
         const node = userFullNameNode.parentElement;
+        node.classList.replace('space-x-2', 'space-x-0.5');
         node.style.setProperty('display', 'flex', 'important');
         node.style.setProperty('align-items', 'center', 'important');
 
@@ -351,6 +357,7 @@ export class Scraper {
         const rect = userFullNameNode.getBoundingClientRect();
 
         const node = userFullNameNode.parentElement;
+        node.classList.remove('space-x-2');
         node.style.setProperty('display', 'flex', 'important');
         node.style.setProperty('align-items', 'center', 'important');
 

--- a/apps/extension/src/host/warpcast/scraper.ts
+++ b/apps/extension/src/host/warpcast/scraper.ts
@@ -42,28 +42,10 @@ export class Scraper {
 
     return posts
       .map((post) => {
-        const links = [...post.querySelectorAll('a')];
-        const usernameClasslist = [
-          'font-semibold',
-          'text-default',
-          'hover:underline',
-        ];
-        const repostUsernameClasslist = [
-          'font-semibold',
-          'text-sm',
-          'hover:underline',
-        ];
+        const links = [...post.querySelectorAll('a.font-semibold.hover\\:underline[data-idrissid]')];
 
-        const usernameLinkNode = links.find((link) => {
-          return usernameClasslist.every((className) => {
-            return link.classList.contains(className);
-          });
-        });
-        const repostUsernameLinkNode = links.find((link) => {
-          return repostUsernameClasslist.every((className) => {
-            return link.classList.contains(className);
-          });
-        });
+        const usernameLinkNode = links.length > 0 ? links[0] : undefined;
+        const repostUsernameLinkNode = links.length > 1 ? links[1] : undefined;
 
         const username = usernameLinkNode
           ?.getAttribute('href')
@@ -456,13 +438,14 @@ export class Scraper {
   private static getUserFromDirectCastConversation() {
     const link = Scraper.getMain()?.querySelector('nav div > span > a');
     const username = link?.getAttribute('href')?.replace('/', '');
-    const userFullNameNode = link?.querySelector(':scope > div > span');
-    if (!username || !userFullNameNode?.parentElement) {
+    const userFullNameNode = link?.querySelector(':scope > span');
+    if (!username || !userFullNameNode?.parentElement || !userFullNameNode.parentElement.parentElement) {
       return;
     }
-    const node = userFullNameNode.parentElement;
+    const node = userFullNameNode.parentElement.parentElement;
     node.style.setProperty('display', 'flex', 'important');
     node.style.setProperty('align-items', 'center', 'important');
+    node.style.setProperty('justify-items', 'center', 'important');
     const rect = node.getBoundingClientRect();
 
     return {

--- a/apps/extension/src/host/warpcast/scraper.ts
+++ b/apps/extension/src/host/warpcast/scraper.ts
@@ -44,7 +44,7 @@ export class Scraper {
       .map((post) => {
         const links = [
           ...post.querySelectorAll(
-            'a.font-semibold.hover:underline[data-idrissid]',
+            String.raw`a.font-semibold.hover\:underline[data-idrissid]`,
           ),
         ];
 


### PR DESCRIPTION
## Overview
This update refines the scraping methods to adapt to Warpcast's HTML/CSS changes, ensuring reliable extraction of usernames and recast usernames.

### How it was fixed
- replaced the previous CSS selector for scraping posts from warpcast with a more specific one, as warpcast's update to their HTML/CSS structure removed the ability to distinguish between usernames and recast usernames based on the tailwind font size classes

- updated the CSS selector to specifically target anchor tags with `font-semibold`, `hover:underline` tailwind classes and `data-idrissid` attribute, ensuring correct selection of both usernames and recast usernames

- refined the `getUserFromDirectCastConversation` method by adjusting element selection logic to accommodate warpcast’s updated structure. The updated method ensures proper alignment of user elements, using `flex` styling on the appropriate parent elements and correctly selecting the user’s full name node

- unified widget icon margin between warpcast and twitter, by removing and/or replacing space-x-2 tailwind class to adjust the margin from 8px to 2px, aligning it with the twitter layout (our widget icon has a margin-left 2px applied by default)

- resolved squashed elements issue in the notifications tab while preserving correct styles and alignment across other sections

### How to test
Check if usernames and recast usernames are accurately scraped and that the IDRISS widget icon is displayed where expected on every page/view.

### Manual Testing 

#### Checklist
- [x] Check if usernames are correctly scraped from posts.
- [x] Validate that recast usernames are accurately scraped from posts.
- [x] Verify that username and IDRISS widget icon elements are aligned properly in the conversation view.
- [x] Test the scraping behavior across the home page feed/timeline, post page, followers & members lists, and direct messages, ensuring there are no unexpected issues or layout breaks.

#### Proof / Screenshots
<img src="https://github.com/user-attachments/assets/a61d9295-5f03-48df-9706-5eb86465244b" width="800"/>
<img src="https://github.com/user-attachments/assets/ead6455a-c24b-44a7-9087-ddaa308e1bd2" width="400"/>
<img src="https://github.com/user-attachments/assets/fb6d414d-9f1f-49f3-b2d6-ad5828b36306" width="400"/>
<img src="https://github.com/user-attachments/assets/cc7c03c5-c4ea-4f47-94b8-4c1f6f34a7e3" width="400"/>
<img src="https://github.com/user-attachments/assets/a23d9384-56d1-4225-a5c1-c3d24f912500" width="400"/>
<img src="https://github.com/user-attachments/assets/cdf6b868-6ec6-460b-a187-3eda28b4d753" width="400"/>
<img src="https://github.com/user-attachments/assets/98b84258-9691-4ff6-9d58-510d05c482fd" width="400"/>
<img src="https://github.com/user-attachments/assets/14f4b880-e8dd-4850-aae2-6bbf0357b7ae" width="400"/>