### PR TITLE
fix: update rendering condition to display in restricted regions

### DIFF
--- a/apps/extension/src/application/polymarket/widgets/market-widget.container.tsx
+++ b/apps/extension/src/application/polymarket/widgets/market-widget.container.tsx
@@ -97,7 +97,7 @@ export const MarketWidgetContainer = memo(
       !tokensPricesQuery.data ||
       imageQuery.data === undefined ||
       chanceQuery.data === undefined ||
-      !availabilityQuery.data ||
+      availabilityQuery.data === undefined ||
       marketQuery.data.closed ||
       tokens.length === 0
     ) {


### PR DESCRIPTION
Changed rendering condition to display polymarket popup also in restricted regions, but with disabled button