### PR TITLE
fix: zoom in issue with hexagons in hero section

### DIFF
--- a/apps/main-landing/src/components/hero-section/hero-section.tsx
+++ b/apps/main-landing/src/components/hero-section/hero-section.tsx
@@ -54,10 +54,11 @@ export const HeroSection = () => {
           'pointer-events-none z-0 mt-[-40%] w-full min-w-[600px]',
           '[@media(max-width:768px)]:[@media(min-width:470px)]:mt-[-30%]',
           'md:mt-[-25%]',
-          'lg:mt-[-33%] lg:min-w-[1985px]',
-          '2xl:mt-[-30%]',
-          '3xl:mt-[-29%]',
-          '4xl:mt-[-24%] 4xl:min-w-[unset]',
+          'lg:mt-[-33%] lg:min-w-[1024px] lg:pb-28 lg:pt-36',
+          'xl:pb-32',
+          '2xl:mt-[-30%] 2xl:pb-24 2xl:pt-28',
+          '3xl:mt-[-29%] 3xl:pb-16 3xl:pt-24',
+          '4xl:mt-[-24%] 4xl:min-w-[unset] 4xl:pb-8 4xl:pt-10',
         )}
         alt=""
       />


### PR DESCRIPTION
## Overview

- fixed hexagons image's minimum width above 1024px (lg) to resolve the 'zoom in' issue

- adjusted the spacing above and below after changing the minimum width

### Proof

#### Before

https://github.com/user-attachments/assets/84120a54-0309-4593-b76b-0cd4102bb0e2

#### After


https://github.com/user-attachments/assets/f170bfff-42ca-42a1-aff9-c2681a4d2903