### PR TITLE
feat: rearranged token section layout

### DIFF
--- a/apps/main-landing/src/components/footer/footer.tsx
+++ b/apps/main-landing/src/components/footer/footer.tsx
@@ -18,7 +18,8 @@ export const Footer = () => {
     <footer
       className={classes(
         'relative z-1 overflow-x-hidden bg-mint-100 p-2.5',
-        'lg:p-0',
+        'lg:-z-10 lg:p-0',
+        '4xl:z-40',
       )}
     >
       <div className="px-safe">

--- a/apps/main-landing/src/components/products-section/components/desktop-products-section.tsx
+++ b/apps/main-landing/src/components/products-section/components/desktop-products-section.tsx
@@ -252,7 +252,7 @@ export const DesktopProductsSection = ({
         className={classes('relative flex bg-mint-100', className)}
         ref={containerReference}
       >
-        <div className="sticky left-0 top-0 z-[99999] h-screen w-screen">
+        <div className="sticky left-0 top-0 z-30 h-screen w-screen">
           <ProductSection
             marginX={margin}
             marginY={margin / 2}

--- a/apps/main-landing/src/components/products-section/components/product-section.tsx
+++ b/apps/main-landing/src/components/products-section/components/product-section.tsx
@@ -96,6 +96,7 @@ export const ProductSection = ({
               'lg:absolute lg:left-0 lg:top-0 lg:h-screen lg:w-screen lg:pt-10 lg:will-change-[margin-left]',
               '2xl:gap-6',
               '3xl:gap-10',
+              '4xl:z-0',
             )}
             style={
               marginX === undefined

--- a/apps/main-landing/src/components/token-section/components/index.ts
+++ b/apps/main-landing/src/components/token-section/components/index.ts
@@ -1,3 +1,4 @@
+// ts-unused-exports:disable-next-line
 export { LabeledGradientProperty } from './labeled-gradient-property';
 // ts-unused-exports:disable-next-line
 export { CopyAddressButton } from './copy-address-button';

--- a/apps/main-landing/src/components/token-section/components/labeled-gradient-property.tsx
+++ b/apps/main-landing/src/components/token-section/components/labeled-gradient-property.tsx
@@ -8,6 +8,7 @@ type Properties = {
   additionalContent?: ReactNode;
 };
 
+// ts-unused-exports:disable-next-line
 export const LabeledGradientProperty = ({
   label,
   content,

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -28,7 +28,8 @@ export const TokenSection = () => {
               'relative flex w-full flex-col items-center gap-[15px] rounded-[36px] bg-white/50 px-4 py-10 backdrop-blur-[45px]',
               'md:px-10 lg:w-[893px]',
               'lg:px-[54px] lg:py-[60px]',
-              '2xl:w-[803px] 2xl:px-10 2xl:pb-[60px] 2xl:pt-10',
+              '2xl:px-10 2xl:pb-[60px] 2xl:pt-10',
+              '3xl:px-8',
             )}
           >
             <GradientBorder
@@ -61,7 +62,7 @@ export const TokenSection = () => {
               className={classes(
                 'mb-2 mt-4 text-balance text-center text-body3 text-neutralGreen-900 opacity-70',
                 'lg:text-body2',
-                '4xl:text-body1',
+                '4xl:text-body',
               )}
             >
               IDRISS is the utility token powering{'\u00A0'}the IDRISS{'\u00A0'}
@@ -70,113 +71,73 @@ export const TokenSection = () => {
               decentralized{'\u00A0'}revenue sharing, governance rights, and
               more.
             </p>
-            {/* Mobile */}
-            <div
-              className={classes(
-                'mb-3 flex flex-row justify-center gap-6',
-                'md:mb-4',
-                'lg:hidden',
-              )}
-            >
-              <Button
-                intent="tertiary"
-                size="medium"
-                suffixIconName="IdrissArrowRight"
-                asLink
-                href="https://docs.idriss.xyz/idriss-token/token-sale#faq"
-                isExternal
-              >
-                FAQ
-              </Button>
-              <Button
-                intent="tertiary"
-                size="medium"
-                suffixIconName="IdrissArrowRight"
-                asLink
-                href="https://docs.idriss.xyz/idriss-token"
-                isExternal
-              >
-                TOKENOMICS
-              </Button>
-            </div>
-            {/* Desktop */}
-            <div className="hidden flex-row justify-normal gap-6 lg:flex">
-              <Button
-                intent="tertiary"
-                size="large"
-                suffixIconName="IdrissArrowRight"
-                asLink
-                href="https://docs.idriss.xyz/idriss-token/token-sale#faq"
-                isExternal
-              >
-                FAQ
-              </Button>
-              <Button
-                intent="tertiary"
-                size="large"
-                suffixIconName="IdrissArrowRight"
-                asLink
-                href="https://docs.idriss.xyz/idriss-token"
-                isExternal
-              >
-                TOKENOMICS
-              </Button>
-            </div>
-            <div className="flex flex-col gap-6 lg:gap-4">
-              <div className="flex flex-col justify-center gap-6 md:flex-row">
-                <GeoConditionalButton
-                  defaultButton={[
-                    <Button
-                      key="uniswap"
-                      intent="primary"
-                      size="large"
-                      prefixIconName="Uniswap"
-                      asLink
-                      href="https://app.uniswap.org/swap?inputCurrency=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&outputCurrency=0x000096630066820566162C94874A776532705231"
-                      isExternal
-                      className="w-full md:w-auto"
-                    >
-                      BUY ON UNISWAP
-                    </Button>,
-                    <Button
-                      key="jumper"
-                      intent="primary"
-                      size="large"
-                      prefixIconName="Jumper"
-                      asLink
-                      href="https://jumper.exchange/?fromChain=8453&fromToken=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&toChain=8453&toToken=0x000096630066820566162C94874A776532705231"
-                      isExternal
-                      className="w-full whitespace-nowrap md:w-auto"
-                    >
-                      BUY CROSS-CHAIN ON JUMPER
-                    </Button>,
-                  ]}
-                />
+            <div className="flex-row justify-normal gap-6 lg:flex">
+              <div className="flex flex-col gap-6 lg:gap-4">
+                <div className="flex flex-col items-center justify-center gap-6 lg:flex-row">
+                  <GeoConditionalButton
+                    defaultButton={[
+                      <Button
+                        key="uniswap"
+                        intent="primary"
+                        size="large"
+                        prefixIconName="Uniswap"
+                        asLink
+                        href="https://app.uniswap.org/swap?inputCurrency=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&outputCurrency=0x000096630066820566162C94874A776532705231"
+                        isExternal
+                        className="mx-auto w-full md:w-auto"
+                      >
+                        BUY ON UNISWAP
+                      </Button>,
+                      <Button
+                        key="jumper"
+                        intent="primary"
+                        size="large"
+                        prefixIconName="Jumper"
+                        asLink
+                        href="https://jumper.exchange/?fromChain=8453&fromToken=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&toChain=8453&toToken=0x000096630066820566162C94874A776532705231"
+                        isExternal
+                        className="w-full whitespace-nowrap md:w-auto"
+                      >
+                        BUY ON JUMPER
+                      </Button>,
+                    ]}
+                  />
+                  <Button
+                    intent="tertiary"
+                    size="large"
+                    suffixIconName="IdrissArrowRight"
+                    asLink
+                    href="https://docs.idriss.xyz/idriss-token"
+                    isExternal
+                  >
+                    TOKENOMICS
+                  </Button>
+                </div>
+                <div className="self-stretch text-center opacity-70">
+                  <span
+                    className={classes(
+                      'text-body4 text-neutralGreen-900',
+                      'md:text-body3',
+                    )}
+                  >
+                    By purchasing, you agree to the{' '}
+                  </span>
+                  <Link
+                    size="medium"
+                    href={TOKEN_TERMS_AND_CONDITIONS_LINK}
+                    isExternal
+                    className={classes(
+                      'text-body4',
+                      'md:text-body3',
+                      //lg here is intentional to override the Link variant style
+                      'lg:text-body3',
+                    )}
+                  >
+                    Terms{'\u00A0'}and{'\u00A0'}conditions
+                  </Link>
+                </div>
+                <div className="flex justify-center" />
               </div>
-              <div className="self-stretch text-center opacity-70">
-                <span
-                  className={classes(
-                    'text-body4 text-neutralGreen-900',
-                    'md:text-body2',
-                  )}
-                >
-                  By purchasing, you agree to the{' '}
-                </span>
-                <Link
-                  size="medium"
-                  href={TOKEN_TERMS_AND_CONDITIONS_LINK}
-                  isExternal
-                  className={classes(
-                    'text-body4',
-                    'md:text-body2',
-                    //lg here is intentional to override the Link variant style
-                    'lg:text-body2',
-                  )}
-                >
-                  Terms{'\u00A0'}and{'\u00A0'}conditions
-                </Link>
-              </div>
-              <div className="flex justify-center" />
             </div>
           </div>
           <img

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -13,7 +13,10 @@ import { GeoConditionalButton } from './components/geo-conditional-button';
 
 export const TokenSection = () => {
   return (
-    <div className="relative z-1 px-safe" id="token">
+    <div
+      className="relative z-40 overflow-visible px-safe lg:h-[100vh] 3xl:h-[unset]"
+      id="token"
+    >
       <div
         className={classes(
           'container flex flex-col items-center justify-center py-10',
@@ -44,8 +47,8 @@ export const TokenSection = () => {
               src={idrissCoin.src}
               alt="IDRISS coin"
               className={classes(
-                'size-[164px]',
-                'lg:mb-2.5 lg:size-[200px]',
+                'mb-6 size-[164px]',
+                'lg:size-[200px]',
                 '2xl:size-[136px]',
               )}
             />
@@ -60,14 +63,14 @@ export const TokenSection = () => {
             </h2>
             <p
               className={classes(
-                'mb-2 mt-4 text-balance text-center text-body3 text-neutralGreen-900 opacity-70',
+                'mb-9 text-balance text-center text-body3 text-neutralGreen-900 opacity-70',
                 'lg:text-body2',
                 '4xl:text-body',
               )}
             >
               IDRISS is the utility token powering{'\u00A0'}the IDRISS{'\u00A0'}
-              DAO,
-              <br className="hidden lg:block" /> giving you access{'\u00A0'}to
+              DAO, giving you access{'\u00A0'}to
+              <br className="hidden lg:block" />
               decentralized{'\u00A0'}revenue sharing, governance rights, and
               more.
             </p>
@@ -103,7 +106,7 @@ export const TokenSection = () => {
                     ]}
                   />
                   <Button
-                    intent="tertiary"
+                    intent="secondary"
                     size="large"
                     suffixIconName="IdrissArrowRight"
                     asLink
@@ -116,8 +119,8 @@ export const TokenSection = () => {
                 <div className="self-stretch text-center opacity-70">
                   <span
                     className={classes(
-                      'text-body4 text-neutralGreen-900',
-                      'md:text-body3',
+                      'text-body5 text-neutralGreen-900',
+                      'md:text-body5',
                     )}
                   >
                     By purchasing, you agree to the{' '}
@@ -127,10 +130,10 @@ export const TokenSection = () => {
                     href={TOKEN_TERMS_AND_CONDITIONS_LINK}
                     isExternal
                     className={classes(
-                      'text-body4',
-                      'md:text-body3',
+                      'border-none text-body5',
+                      'md:text-body5',
                       //lg here is intentional to override the Link variant style
-                      'lg:text-body3',
+                      'lg:text-body5',
                     )}
                   >
                     Terms{'\u00A0'}and{'\u00A0'}conditions
@@ -142,7 +145,7 @@ export const TokenSection = () => {
           </div>
           <img
             src={background.src}
-            className="pointer-events-none absolute left-0 top-0 -z-1 size-full overflow-visible object-cover"
+            className="pointer-events-none absolute left-0 top-0 -z-10 size-full overflow-visible object-cover"
             alt=""
           />
         </div>

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -6,10 +6,19 @@ import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
 import { Link } from '@idriss-xyz/ui/link';
 import { classes } from '@idriss-xyz/ui/utils';
 import { TOKEN_TERMS_AND_CONDITIONS_LINK } from '@idriss-xyz/constants';
+import dynamic from 'next/dynamic';
 
 import idrissCoin from './assets/IDRISS_COIN 1.png';
 import background from './background.png';
 import { GeoConditionalButton } from './components/geo-conditional-button';
+
+const TokenomicsButton = dynamic(
+  async () => {
+    const { Button } = await import('@idriss-xyz/ui/button');
+    return Button;
+  },
+  { ssr: false },
+);
 
 export const TokenSection = () => {
   return (
@@ -105,7 +114,7 @@ export const TokenSection = () => {
                       </Button>,
                     ]}
                   />
-                  <Button
+                  <TokenomicsButton
                     intent="secondary"
                     size="large"
                     suffixIconName="IdrissArrowRight"
@@ -114,7 +123,7 @@ export const TokenSection = () => {
                     isExternal
                   >
                     TOKENOMICS
-                  </Button>
+                  </TokenomicsButton>
                 </div>
                 <div className="self-stretch text-center opacity-70">
                   <span

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -25,7 +25,7 @@ export const TokenSection = () => {
         <div className="flex flex-col items-center">
           <div
             className={classes(
-              'relative flex w-full flex-col items-center gap-[40px] rounded-[36px] bg-white/50 px-4 py-10 backdrop-blur-[45px]',
+              'relative flex w-full flex-col items-center gap-[15px] rounded-[36px] bg-white/50 px-4 py-10 backdrop-blur-[45px]',
               'md:px-10 lg:w-[893px]',
               'lg:px-[54px] lg:py-[60px]',
               '2xl:w-[803px] 2xl:px-10 2xl:pb-[60px] 2xl:pt-10',

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -14,7 +14,7 @@ import { GeoConditionalButton } from './components/geo-conditional-button';
 export const TokenSection = () => {
   return (
     <div
-      className="relative z-40 overflow-visible px-safe lg:h-[100vh] 3xl:h-[unset]"
+      className="relative z-40 overflow-visible px-safe lg:h-screen 3xl:h-[unset]"
       id="token"
     >
       <div

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -3,35 +3,13 @@
 
 import { Button } from '@idriss-xyz/ui/button';
 import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
-import dynamic from 'next/dynamic';
 import { Link } from '@idriss-xyz/ui/link';
 import { classes } from '@idriss-xyz/ui/utils';
 import { TOKEN_TERMS_AND_CONDITIONS_LINK } from '@idriss-xyz/constants';
 
 import idrissCoin from './assets/IDRISS_COIN 1.png';
 import background from './background.png';
-import { LabeledGradientProperty } from './components';
 import { GeoConditionalButton } from './components/geo-conditional-button';
-
-const CopyAddressButton = dynamic(
-  async () => {
-    const { CopyAddressButton } = await import(
-      './components/copy-address-button'
-    );
-    return CopyAddressButton;
-  },
-  { ssr: false },
-);
-
-const TokenSaleCountdown = dynamic(
-  async () => {
-    const { TokenSaleCountdown } = await import(
-      './components/token-sale-countdown'
-    );
-    return TokenSaleCountdown;
-  },
-  { ssr: false },
-);
 
 export const TokenSection = () => {
   return (
@@ -45,79 +23,6 @@ export const TokenSection = () => {
         )}
       >
         <div className="flex flex-col items-center">
-          <h2
-            className={classes(
-              'text-heading3 gradient-text',
-              'md:text-display4',
-              'lg:text-display3',
-            )}
-          >
-            TOKEN SALE
-          </h2>
-          <p
-            className={classes(
-              'mb-2 mt-4 text-balance text-center text-body3 text-neutralGreen-900 opacity-70',
-              'lg:text-body2',
-              '4xl:text-body1',
-            )}
-          >
-            IDRISS is the utility token powering{'\u00A0'}the IDRISS{'\u00A0'}
-            DAO,
-            <br className="hidden lg:block" /> giving you access{'\u00A0'}to
-            decentralized{'\u00A0'}revenue sharing, governance rights, and more.
-          </p>
-          {/* Mobile */}
-          <div
-            className={classes(
-              'mb-3 flex flex-row justify-center gap-6',
-              'md:mb-4',
-              'lg:hidden',
-            )}
-          >
-            <Button
-              intent="tertiary"
-              size="medium"
-              suffixIconName="IdrissArrowRight"
-              asLink
-              href="https://docs.idriss.xyz/idriss-token/token-sale#faq"
-              isExternal
-            >
-              FAQ
-            </Button>
-            <Button
-              intent="tertiary"
-              size="medium"
-              suffixIconName="IdrissArrowRight"
-              asLink
-              href="https://docs.idriss.xyz/idriss-token"
-              isExternal
-            >
-              TOKENOMICS
-            </Button>
-          </div>
-          {/* Desktop */}
-          <div className="mb-4 hidden flex-row justify-normal gap-6 lg:flex">
-            <Button
-              intent="tertiary"
-              size="large"
-              suffixIconName="IdrissArrowRight"
-              asLink
-              href="https://docs.idriss.xyz/idriss-token/token-sale#faq"
-              isExternal
-            >
-              FAQ
-            </Button>
-            <Button
-              intent="tertiary"
-              size="large"
-              suffixIconName="IdrissArrowRight"
-              asLink
-              href="https://docs.idriss.xyz/idriss-token"
-              isExternal
-            >
-              TOKENOMICS
-            </Button>
-          </div>
           <div
             className={classes(
               'relative flex w-full flex-col items-center gap-[40px] rounded-[36px] bg-white/50 px-4 py-10 backdrop-blur-[45px]',
@@ -143,18 +48,80 @@ export const TokenSection = () => {
                 '2xl:size-[136px]',
               )}
             />
-            <div className="flex w-full flex-wrap justify-between gap-2">
-              <LabeledGradientProperty
-                label="TOKEN"
-                content="IDRISS"
-                additionalContent={<CopyAddressButton />}
-                className="mb-8 w-full md:w-fit lg:mb-0"
-              />
-              <LabeledGradientProperty label="FOR SALE" content="5%" />
-              <LabeledGradientProperty label="FDV" content="$30M" />
-              <LabeledGradientProperty label="PRICE" content="$0.03" />
+            <h2
+              className={classes(
+                'text-heading3 gradient-text',
+                'md:text-display4',
+                'lg:text-display3',
+              )}
+            >
+              TOKEN
+            </h2>
+            <p
+              className={classes(
+                'mb-2 mt-4 text-balance text-center text-body3 text-neutralGreen-900 opacity-70',
+                'lg:text-body2',
+                '4xl:text-body1',
+              )}
+            >
+              IDRISS is the utility token powering{'\u00A0'}the IDRISS{'\u00A0'}
+              DAO,
+              <br className="hidden lg:block" /> giving you access{'\u00A0'}to
+              decentralized{'\u00A0'}revenue sharing, governance rights, and
+              more.
+            </p>
+            {/* Mobile */}
+            <div
+              className={classes(
+                'mb-3 flex flex-row justify-center gap-6',
+                'md:mb-4',
+                'lg:hidden',
+              )}
+            >
+              <Button
+                intent="tertiary"
+                size="medium"
+                suffixIconName="IdrissArrowRight"
+                asLink
+                href="https://docs.idriss.xyz/idriss-token/token-sale#faq"
+                isExternal
+              >
+                FAQ
+              </Button>
+              <Button
+                intent="tertiary"
+                size="medium"
+                suffixIconName="IdrissArrowRight"
+                asLink
+                href="https://docs.idriss.xyz/idriss-token"
+                isExternal
+              >
+                TOKENOMICS
+              </Button>
             </div>
-            <TokenSaleCountdown />
+            {/* Desktop */}
+            <div className="hidden flex-row justify-normal gap-6 lg:flex">
+              <Button
+                intent="tertiary"
+                size="large"
+                suffixIconName="IdrissArrowRight"
+                asLink
+                href="https://docs.idriss.xyz/idriss-token/token-sale#faq"
+                isExternal
+              >
+                FAQ
+              </Button>
+              <Button
+                intent="tertiary"
+                size="large"
+                suffixIconName="IdrissArrowRight"
+                asLink
+                href="https://docs.idriss.xyz/idriss-token"
+                isExternal
+              >
+                TOKENOMICS
+              </Button>
+            </div>
             <div className="flex flex-col gap-6 lg:gap-4">
               <div className="flex flex-col justify-center gap-6 md:flex-row">
                 <GeoConditionalButton
@@ -209,6 +176,7 @@ export const TokenSection = () => {
                   Terms{'\u00A0'}and{'\u00A0'}conditions
                 </Link>
               </div>
+              <div className="flex justify-center" />
             </div>
           </div>
           <img


### PR DESCRIPTION
## Overview

- rearranged token section layout according to new mockups and cleaned up afterwards

- fixed background hexagons overlap

- added lazy loading for tokenomics button

### Proof

![image](https://github.com/user-attachments/assets/c4c84e0a-9852-400e-b1cb-fef51138f30c)
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/87f596a8-4fd5-4840-a79d-4f62fb76edb3" />
![image](https://github.com/user-attachments/assets/a3637e52-4b41-4f1e-97d9-7941098a3ad3)
![image](https://github.com/user-attachments/assets/a440d1e6-7bfb-48fe-8ebf-fd39c223824d)

