### PR TITLE
fix: initialize subscriptions refresh listener only once

### DIFF
--- a/apps/extension/src/application/trading-copilot/subscriptions-management/subscriptions-management.types.ts
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/subscriptions-management.types.ts
@@ -1,3 +1,9 @@
-export interface ContentProperties {
+import { MutableRefObject } from 'react';
+
+export interface Properties {
+  isTabChangedListenerAdded: MutableRefObject<boolean>;
+}
+
+export interface ContentProperties extends Properties {
   subscriberId: string;
 }

--- a/apps/extension/src/final/extension-popup/extension-popup.tsx
+++ b/apps/extension/src/final/extension-popup/extension-popup.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router';
+import { useRef } from 'react';
 
 import { Closable } from 'shared/ui';
 import { POPUP_ROUTE, useExtensionPopup } from 'shared/extension';
@@ -21,6 +22,7 @@ import {
 
 export const ExtensionPopup = () => {
   const extensionPopup = useExtensionPopup();
+  const isTabChangedListenerAdded = useRef(false);
 
   if (!extensionPopup.isVisible) {
     return null;
@@ -55,7 +57,11 @@ export const ExtensionPopup = () => {
           <Route element={<TradingCopilotLayout />}>
             <Route
               path={POPUP_ROUTE.TRADING_COPILOT}
-              element={<SubscriptionsManagement />}
+              element={
+                <SubscriptionsManagement
+                  isTabChangedListenerAdded={isTabChangedListenerAdded}
+                />
+              }
             />
           </Route>
         </Route>


### PR DESCRIPTION
Added verification if subscriptions refresh listener is already initialized to prevent multiple refreshes.