### PR TITLE
fix: make idriss token icon smaller according to mockup

### DIFF
--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -176,7 +176,7 @@ const TradingCopilotDialogContent = ({
               got {roundToSignificantFigures(dialog.tokenIn.amount, 2)}{' '}
               <span className="flex items-center justify-center gap-x-1">
                 {dialog.tokenIn.symbol}
-                <IdrissIcon name="IdrissToken" size={24} />
+                <IdrissIcon name="IdrissToken" size={24} className="h-6 w-6" />
               </span>
             </span>{' '}
             {wallet ? (

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -176,7 +176,7 @@ const TradingCopilotDialogContent = ({
               got {roundToSignificantFigures(dialog.tokenIn.amount, 2)}{' '}
               <span className="flex items-center justify-center gap-x-1">
                 {dialog.tokenIn.symbol}
-                <IdrissIcon name="IdrissToken" size={24} className="h-6 w-6" />
+                <IdrissIcon name="IdrissToken" size={24} className="size-6" />
               </span>
             </span>{' '}
             {wallet ? (

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-toast/trading-copilot-toast.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-toast/trading-copilot-toast.tsx
@@ -33,7 +33,7 @@ export const TradingCopilotToast = ({
           <span className="text-body3 text-neutral-600">
             purchased {roundToSignificantFigures(toast.tokenIn.amount, 2)}{' '}
             <span className="flex items-center justify-center space-x-1">
-              <IdrissIcon name="IdrissToken" size={24} className="h-6 w-6" />
+              <IdrissIcon name="IdrissToken" size={24} className="size-6" />
               <span>{toast.tokenIn.symbol}</span>
             </span>
           </span>

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-toast/trading-copilot-toast.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-toast/trading-copilot-toast.tsx
@@ -33,7 +33,7 @@ export const TradingCopilotToast = ({
           <span className="text-body3 text-neutral-600">
             purchased {roundToSignificantFigures(toast.tokenIn.amount, 2)}{' '}
             <span className="flex items-center justify-center space-x-1">
-              <IdrissIcon name="IdrissToken" size={24} />
+              <IdrissIcon name="IdrissToken" size={24} className="h-6 w-6" />
               <span>{toast.tokenIn.symbol}</span>
             </span>
           </span>


### PR DESCRIPTION
## Overview

- fixed idriss token icon svg initial size being too big (made it 24px x 24px according to mockups Figma)