### PR TITLE
feat: add handling of subscriberId in test swap

### DIFF
--- a/apps/copilot-api/routes/index.ts
+++ b/apps/copilot-api/routes/index.ts
@@ -53,7 +53,9 @@ router.post('/unsubscribe', verifyToken(), async (req, res) => {
   }
 });
 
-router.get('/test-swap', async (req, res) => {
+router.get('/test-swap/:subscriberId', async (req, res) => {
+  const { subscriberId } = req.params || {};
+
   const swapData = {
     transactionHash:
       '0xcbe526713e8c2095369191287c1fd4c1832716a55abe0b58db7ee91bebe21542',
@@ -84,13 +86,12 @@ router.get('/test-swap', async (req, res) => {
   }
 
   try {
-    const subscriberId = 'id1';
     const clientSocket = connectedClients.get(subscriberId);
     if (clientSocket) {
       clientSocket.emit('swapEvent', swapData);
     }
 
-    res.status(200).json({ message: 'Swap event sent to subscribers' });
+    res.status(200).json({ message: `Swap event sent to ${subscriberId}` });
   } catch (err) {
     throwInternalError(res, 'Error sending swap event', err);
   }


### PR DESCRIPTION
Added handling of custom subscriberId in test swap to make testing easier. 

To send test-swap now we only need to fetch https://copilot-production-e887.up.railway.app/test-swap/{subscriberId} with method GET.

In subscriberId place we put our wallet address, method GET is default option - we can call this even by pasting URL in browser.

Example url with my wallet:
https://copilot-production-e887.up.railway.app/test-swap/0x8637AF884f71ef0e60851940E816dfE163599840
![image](https://github.com/user-attachments/assets/3d6f2983-09ef-47c8-b4ec-bd7ed1b52695)