### PR TITLE
fix: enable notification sound by default and align copilot dialog with figma

### DIFF
--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/sound-toggle/sound-toggle.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/sound-toggle/sound-toggle.tsx
@@ -2,11 +2,13 @@ import { Icon } from '@idriss-xyz/ui/icon';
 import { useState, useEffect } from 'react';
 
 export const SoundToggle = () => {
-  const [isSoundEnabled, setIsSoundEnabled] = useState(false);
+  const [isSoundEnabled, setIsSoundEnabled] = useState(true);
 
   useEffect(() => {
     const enableSound = localStorage.getItem('idriss-widget-enable-sound');
-    setIsSoundEnabled(enableSound === 'true');
+    if (enableSound !== null) {
+      setIsSoundEnabled(enableSound === 'true');
+    }
   }, []);
 
   const toggleSound = () => {

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -150,12 +150,13 @@ const TradingCopilotDialogContent = ({
 
   return (
     <>
-      <div className="flex flex-row items-center justify-between">
+      <div className="flex h-[28px] flex-row items-center justify-between">
         <h1 className="text-heading4 text-neutral-900">Copy trade</h1>
         <IconButton
           intent="tertiary"
           size="medium"
           iconName="X"
+          className="pr-0 pt-1.5 text-neutral-600"
           onClick={closeDialog}
         />
       </div>


### PR DESCRIPTION
## Overview

- enabled notification sound (toggle in copilot) by default

- aligned trading-copilot-dialog component with mockup from figma (adjusted spacing above the title, X icon placement and it's color)


### Proof (using mocked data)
![image](https://github.com/user-attachments/assets/2051af52-7681-46c5-9714-299f07171643)
