### PR TITLE
fix: footer unclickable links in between lg and 4xl devices

### DIFF
--- a/apps/main-landing/src/components/footer/footer.tsx
+++ b/apps/main-landing/src/components/footer/footer.tsx
@@ -18,7 +18,7 @@ export const Footer = () => {
     <footer
       className={classes(
         'relative z-1 overflow-x-hidden bg-mint-100 p-2.5',
-        'lg:-z-10 lg:p-0',
+        'lg:z-10 lg:p-0',
         '4xl:z-40',
       )}
     >


### PR DESCRIPTION
## Overview

- fix footer unclickable links in between lg and 4xl devices due to negative z-index

### Proof
<img width="736" alt="image" src="https://github.com/user-attachments/assets/66271f33-268a-418c-a78c-2ad6dacf817d" />
