### PR TITLE
feat: move authToken from localStorage to context

### DIFF
--- a/apps/extension/src/application/trading-copilot/commands/get-quote.ts
+++ b/apps/extension/src/application/trading-copilot/commands/get-quote.ts
@@ -21,7 +21,7 @@ export class GetQuoteCommand extends Command<Payload, Response> {
     try {
       const response = await fetch(`${COPILOT_API_URL}/get-quote`, {
         method: 'POST',
-        body: JSON.stringify(this.payload),
+        body: JSON.stringify(this.payload.quote),
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${this.payload.authToken}`,

--- a/apps/extension/src/application/trading-copilot/hooks/use-exchanger.ts
+++ b/apps/extension/src/application/trading-copilot/hooks/use-exchanger.ts
@@ -3,6 +3,7 @@ import { formatEther, parseEther } from 'viem';
 
 import { Wallet, CHAIN } from 'shared/web3';
 import { useCommandMutation } from 'shared/messaging';
+import { useAuthToken } from 'shared/extension';
 
 import { SwapData, FormValues, QuotePayload } from '../types';
 import { GetQuoteCommand } from '../commands/get-quote';
@@ -19,6 +20,7 @@ interface CallbackProperties {
 }
 
 export const useExchanger = ({ wallet }: Properties) => {
+  const { authToken } = useAuthToken();
   const quoteQuery = useCommandMutation(GetQuoteCommand);
   const copilotTransaction = useCopilotTransaction();
 
@@ -36,13 +38,15 @@ export const useExchanger = ({ wallet }: Properties) => {
       const amountInWei = parseEther(amountInEth).toString();
 
       const quotePayload = {
-        amount: amountInWei,
-        destinationChain: CHAIN[dialog.tokenOut.network].id,
-        fromAddress: wallet.account,
-        destinationToken: dialog.tokenIn.address,
-        originChain: CHAIN[dialog.tokenIn.network].id,
-        originToken: '0x0000000000000000000000000000000000000000',
-        authToken: localStorage.getItem('authToken') ?? '',
+        quote: {
+          amount: amountInWei,
+          destinationChain: CHAIN[dialog.tokenOut.network].id,
+          fromAddress: wallet.account,
+          destinationToken: dialog.tokenIn.address,
+          originChain: CHAIN[dialog.tokenIn.network].id,
+          originToken: '0x0000000000000000000000000000000000000000',
+        },
+        authToken: authToken ?? '',
       };
 
       const quoteData = await handleQuoteQuery(quotePayload);
@@ -62,7 +66,7 @@ export const useExchanger = ({ wallet }: Properties) => {
         transactionData,
       });
     },
-    [copilotTransaction, quoteQuery, wallet],
+    [authToken, copilotTransaction, quoteQuery, wallet],
   );
 
   const isSending = quoteQuery.isPending || copilotTransaction.isPending;

--- a/apps/extension/src/application/trading-copilot/hooks/use-login-via-siwe.ts
+++ b/apps/extension/src/application/trading-copilot/hooks/use-login-via-siwe.ts
@@ -2,11 +2,13 @@ import { useCallback } from 'react';
 
 import { useCommandMutation } from 'shared/messaging';
 import { createWalletClient, Wallet } from 'shared/web3';
+import { useAuthToken } from 'shared/extension';
 
 import { GetSiweMessageCommand, VerifySiweSignatureCommand } from '../commands';
 import { SiweMessageRequest, VerifySiweSignatureRequest } from '../types';
 
 export const useLoginViaSiwe = () => {
+  const { authToken, saveAuthToken } = useAuthToken();
   const getSiweMessage = useCommandMutation(GetSiweMessageCommand);
   const verifySiweSignature = useCommandMutation(VerifySiweSignatureCommand);
 
@@ -45,16 +47,14 @@ export const useLoginViaSiwe = () => {
         signature: siweSignature,
       });
 
-      localStorage.setItem('authToken', verifiedSiweSignature.token);
+      saveAuthToken(verifiedSiweSignature.token);
     },
-    [getSiweMessage, verifySiweSignature],
+    [getSiweMessage, saveAuthToken, verifySiweSignature],
   );
 
   const loggedIn = useCallback(() => {
-    const authToken = localStorage.getItem('authToken');
-
     return !!authToken;
-  }, []);
+  }, [authToken]);
 
   const isSending = getSiweMessage.isPending || verifySiweSignature.isPending;
 

--- a/apps/extension/src/application/trading-copilot/hooks/use-login-via-siwe.ts
+++ b/apps/extension/src/application/trading-copilot/hooks/use-login-via-siwe.ts
@@ -8,7 +8,7 @@ import { GetSiweMessageCommand, VerifySiweSignatureCommand } from '../commands';
 import { SiweMessageRequest, VerifySiweSignatureRequest } from '../types';
 
 export const useLoginViaSiwe = () => {
-  const { authToken, saveAuthToken } = useAuthToken();
+  const { getAuthToken, saveAuthToken } = useAuthToken();
   const getSiweMessage = useCommandMutation(GetSiweMessageCommand);
   const verifySiweSignature = useCommandMutation(VerifySiweSignatureCommand);
 
@@ -52,9 +52,7 @@ export const useLoginViaSiwe = () => {
     [getSiweMessage, saveAuthToken, verifySiweSignature],
   );
 
-  const loggedIn = useCallback(() => {
-    return !!authToken;
-  }, [authToken]);
+  const loggedIn = getAuthToken;
 
   const isSending = getSiweMessage.isPending || verifySiweSignature.isPending;
 

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscription-form.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscription-form.tsx
@@ -5,7 +5,6 @@ import { useWallet } from '@idriss-xyz/wallet-connect';
 import { useCommandMutation } from 'shared/messaging';
 import { ErrorMessage } from 'shared/ui';
 
-import { useLoginViaSiwe } from '../../hooks';
 import {
   GetEnsAddressCommand,
   GetFarcasterAddressCommand,
@@ -22,7 +21,6 @@ export const SubscriptionForm = ({
   subscriptionsAmount,
 }: Properties) => {
   const { wallet } = useWallet();
-  const siwe = useLoginViaSiwe();
 
   const form = useForm<FormValues>({
     defaultValues: EMPTY_FORM,
@@ -57,14 +55,9 @@ export const SubscriptionForm = ({
       const farcasterPattern = /^[^.]+$/;
       const isWalletAddress = hexPattern.test(data.subscriptionDetails);
       const isFarcasterName = farcasterPattern.test(data.subscriptionDetails);
-      const siweLoggedIn = siwe.loggedIn();
 
       if (!wallet) {
         return;
-      }
-
-      if (!siweLoggedIn) {
-        await siwe.login(wallet);
       }
 
       if (isWalletAddress) {
@@ -103,7 +96,6 @@ export const SubscriptionForm = ({
       getEnsAddressMutation,
       getFarcasterAddressMutation,
       onSubmit,
-      siwe,
       wallet,
     ],
   );

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/subscription-item.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/subscription-item.tsx
@@ -13,7 +13,6 @@ import {
   GetEnsInfoCommand,
   GetFarcasterUserCommand,
 } from '../../../commands';
-import { useLoginViaSiwe } from '../../../hooks';
 
 import {
   ItemProperties,
@@ -81,22 +80,15 @@ const SubscriptionItemContent = ({
   avatar,
 }: ItemContentProperties) => {
   const { wallet } = useWallet();
-  const siwe = useLoginViaSiwe();
   const isFarcasterSubscription = !!farcasterSubscriptionDetails;
 
-  const remove = useCallback(async () => {
-    const siweLoggedIn = siwe.loggedIn();
-
+  const remove = useCallback(() => {
     if (!wallet) {
       return;
     }
 
-    if (!siweLoggedIn) {
-      await siwe.login(wallet);
-    }
-
     onRemove(subscription.address);
-  }, [onRemove, siwe, subscription, wallet]);
+  }, [onRemove, subscription, wallet]);
 
   const emailQuery = useCommandQuery({
     command: new GetEnsInfoCommand({

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/subscriptions-management.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/subscriptions-management.tsx
@@ -9,6 +9,7 @@ import {
   useCommandQuery,
 } from 'shared/messaging';
 import { Empty } from 'shared/ui';
+import { useAuthToken } from 'shared/extension';
 
 import {
   AddTradingCopilotSubscriptionCommand,
@@ -53,6 +54,8 @@ const SubscriptionsManagementContent = ({
   subscriberId,
   isTabChangedListenerAdded,
 }: ContentProperties) => {
+  const { authToken } = useAuthToken();
+
   const subscriptionsQuery = useCommandQuery({
     command: new GetTradingCopilotSubscriptionsCommand({
       subscriberId,
@@ -82,7 +85,7 @@ const SubscriptionsManagementContent = ({
   ) => {
     await subscribe.mutateAsync({
       subscription: { address, fid, subscriberId },
-      authToken: localStorage.getItem('authToken') ?? '',
+      authToken: authToken ?? '',
     });
     void subscriptionsQuery.refetch();
   };
@@ -92,7 +95,7 @@ const SubscriptionsManagementContent = ({
   ) => {
     await unsubscribe.mutateAsync({
       subscription: { address, subscriberId },
-      authToken: localStorage.getItem('authToken') ?? '',
+      authToken: authToken ?? '',
     });
     void subscriptionsQuery.refetch();
   };

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/subscriptions-management.types.ts
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/subscriptions-management.types.ts
@@ -1,9 +1,12 @@
 import { MutableRefObject } from 'react';
 
+import { Wallet } from 'shared/web3';
+
 export interface Properties {
   isTabChangedListenerAdded: MutableRefObject<boolean>;
 }
 
 export interface ContentProperties extends Properties {
   subscriberId: string;
+  wallet: Wallet;
 }

--- a/apps/extension/src/application/trading-copilot/types.ts
+++ b/apps/extension/src/application/trading-copilot/types.ts
@@ -96,12 +96,14 @@ export type SwapData = {
 };
 
 export interface QuotePayload {
-  amount: string;
-  originChain: number;
-  originToken: string;
-  fromAddress: string;
-  destinationToken: string;
-  destinationChain: number;
+  quote: {
+    amount: string;
+    originChain: number;
+    originToken: string;
+    fromAddress: string;
+    destinationToken: string;
+    destinationChain: number;
+  };
   authToken: string;
 }
 

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -27,6 +27,7 @@ import {
   roundToSignificantFiguresForCopilotTrading,
 } from 'shared/web3';
 import { IdrissSend } from 'shared/idriss';
+import { useAuthToken } from 'shared/extension';
 
 import { TokenIcon } from '../../utils';
 import { TradingCopilotTooltip } from '../trading-copilot-tooltip';
@@ -78,6 +79,7 @@ const TradingCopilotDialogContent = ({
   closeDialog,
 }: ContentProperties) => {
   const { wallet, isConnectionModalOpened, openConnectionModal } = useWallet();
+  const { authToken } = useAuthToken();
   const exchanger = useExchanger({ wallet });
   const siwe = useLoginViaSiwe();
 
@@ -257,8 +259,12 @@ const TradingCopilotDialogContent = ({
                 <TokenIcon tokenAddress={dialog.tokenIn.address} />
               </span>
             </span>{' '}
-            {wallet ? (
-              <TradingCopilotTradeValue wallet={wallet} dialog={dialog} />
+            {wallet && authToken ? (
+              <TradingCopilotTradeValue
+                wallet={wallet}
+                dialog={dialog}
+                authToken={authToken}
+              />
             ) : null}
           </p>
           <p className="text-body6 text-mint-700">
@@ -378,18 +384,24 @@ const TradingCopilotWalletBalance = ({ wallet }: WalletBalanceProperties) => {
   );
 };
 
-const TradingCopilotTradeValue = ({ wallet, dialog }: TradeValueProperties) => {
+const TradingCopilotTradeValue = ({
+  wallet,
+  dialog,
+  authToken,
+}: TradeValueProperties) => {
   const amountInEth = dialog.tokenIn.amount.toString();
   const amountInWei = parseEther(amountInEth).toString();
 
   const quotePayload = {
-    amount: amountInWei,
-    destinationChain: CHAIN[dialog.tokenOut.network].id,
-    fromAddress: wallet.account,
-    originToken: dialog.tokenIn.address,
-    originChain: CHAIN[dialog.tokenIn.network].id,
-    destinationToken: '0x0000000000000000000000000000000000000000',
-    authToken: localStorage.getItem('authToken') ?? '',
+    quote: {
+      amount: amountInWei,
+      destinationChain: CHAIN[dialog.tokenOut.network].id,
+      fromAddress: wallet.account,
+      originToken: dialog.tokenIn.address,
+      originChain: CHAIN[dialog.tokenIn.network].id,
+      destinationToken: '0x0000000000000000000000000000000000000000',
+    },
+    authToken: authToken ?? '',
   };
 
   const quoteQuery = useCommandQuery({

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -105,14 +105,8 @@ const TradingCopilotDialogContent = ({
 
   const onSubmit = useCallback(
     async (formValues: FormValues) => {
-      const siweLoggedIn = siwe.loggedIn();
-
       if (!wallet) {
         return;
-      }
-
-      if (!siweLoggedIn) {
-        await siwe.login(wallet);
       }
 
       await exchanger.exchange({
@@ -120,7 +114,7 @@ const TradingCopilotDialogContent = ({
         dialog: dialog,
       });
     },
-    [dialog, exchanger, siwe, wallet],
+    [dialog, exchanger, wallet],
   );
 
   if (exchanger.isSending && exchanger.quoteData?.includedSteps[0]) {

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.types.ts
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.types.ts
@@ -17,4 +17,5 @@ export interface WalletBalanceProperties {
 export interface TradeValueProperties {
   wallet: Wallet;
   dialog: SwapData;
+  authToken: string;
 }

--- a/apps/extension/src/final/widgets/follow-trading-copilot.tsx
+++ b/apps/extension/src/final/widgets/follow-trading-copilot.tsx
@@ -9,8 +9,9 @@ import {
   GetTradingCopilotSubscriptionsCommand,
   RemoveTradingCopilotSubscriptionCommand,
   SubscriptionRequest,
+  useLoginViaSiwe,
 } from 'application/trading-copilot';
-import { Hex } from 'shared/web3';
+import { Hex, Wallet } from 'shared/web3';
 import { useAuthToken } from 'shared/extension';
 
 import { useUserWidgets, useLocationInfo } from '../hooks';
@@ -91,6 +92,7 @@ export const FollowTradingCopilot = () => {
       subscriberId={wallet.account}
       iconHeight={iconHeight}
       portal={portal}
+      wallet={wallet}
       className="mb-3 mr-2 p-1.5"
     />
   );
@@ -137,6 +139,7 @@ export const FollowTradingCopilotBadge = ({
       subscriberId={wallet.account}
       iconHeight={iconSize}
       portal={portal}
+      wallet={wallet}
       className={isHandleUser ? 'ml-1 p-0' : 'ml-0.5 p-0'}
     />
   );
@@ -148,6 +151,7 @@ type ContentProperties = {
   iconHeight: number;
   portal: HTMLDivElement;
   className?: string;
+  wallet: Wallet;
 };
 
 const FollowTradingCopilotContent = ({
@@ -156,8 +160,10 @@ const FollowTradingCopilotContent = ({
   subscriberId,
   userId,
   className,
+  wallet,
 }: ContentProperties) => {
-  const { authToken } = useAuthToken();
+  const siwe = useLoginViaSiwe();
+  const { getAuthToken } = useAuthToken();
 
   const subscriptionsQuery = useCommandQuery({
     command: new GetTradingCopilotSubscriptionsCommand({
@@ -178,6 +184,18 @@ const FollowTradingCopilotContent = ({
   const handleSubscribe = async (
     address: SubscriptionRequest['subscription']['address'],
   ) => {
+    const siweLoggedIn = await siwe.loggedIn();
+
+    if (!siweLoggedIn) {
+      await siwe.login(wallet);
+    }
+
+    const authToken = await getAuthToken();
+
+    if (!authToken) {
+      return;
+    }
+
     await subscribe.mutateAsync({
       subscription: { address, subscriberId },
       authToken: authToken ?? '',
@@ -188,6 +206,18 @@ const FollowTradingCopilotContent = ({
   const handleUnsubscribe = async (
     address: SubscriptionRequest['subscription']['address'],
   ) => {
+    const siweLoggedIn = await siwe.loggedIn();
+
+    if (!siweLoggedIn) {
+      await siwe.login(wallet);
+    }
+
+    const authToken = await getAuthToken();
+
+    if (!authToken) {
+      return;
+    }
+
     await unsubscribe.mutateAsync({
       subscription: { address, subscriberId },
       authToken: authToken ?? '',

--- a/apps/extension/src/final/widgets/follow-trading-copilot.tsx
+++ b/apps/extension/src/final/widgets/follow-trading-copilot.tsx
@@ -11,6 +11,7 @@ import {
   SubscriptionRequest,
 } from 'application/trading-copilot';
 import { Hex } from 'shared/web3';
+import { useAuthToken } from 'shared/extension';
 
 import { useUserWidgets, useLocationInfo } from '../hooks';
 
@@ -156,6 +157,8 @@ const FollowTradingCopilotContent = ({
   userId,
   className,
 }: ContentProperties) => {
+  const { authToken } = useAuthToken();
+
   const subscriptionsQuery = useCommandQuery({
     command: new GetTradingCopilotSubscriptionsCommand({
       subscriberId,
@@ -177,7 +180,7 @@ const FollowTradingCopilotContent = ({
   ) => {
     await subscribe.mutateAsync({
       subscription: { address, subscriberId },
-      authToken: localStorage.getItem('authToken') ?? '',
+      authToken: authToken ?? '',
     });
     void subscriptionsQuery.refetch();
   };
@@ -187,7 +190,7 @@ const FollowTradingCopilotContent = ({
   ) => {
     await unsubscribe.mutateAsync({
       subscription: { address, subscriberId },
-      authToken: localStorage.getItem('authToken') ?? '',
+      authToken: authToken ?? '',
     });
     void subscriptionsQuery.refetch();
   };

--- a/apps/extension/src/infrastructure/application/providers.tsx
+++ b/apps/extension/src/infrastructure/application/providers.tsx
@@ -20,10 +20,11 @@ import {
 } from 'shared/ui';
 import { TwitterScrapingContextProvider } from 'host/twitter';
 import {
+  AuthTokenContextProvider,
   ExtensionPopupProvider,
   ExtensionSettingsProvider,
 } from 'shared/extension';
-import { WalletStorage } from 'shared/web3';
+import { AuthTokenStorage, WalletStorage } from 'shared/web3';
 
 type Properties = {
   children: ReactNode;
@@ -46,26 +47,32 @@ export const Providers = ({
                     <TailwindProvider>
                       <QueryProvider>
                         <NiceModal.Provider>
-                          <NotificationsProvider>
-                            <WalletContextProvider
-                              disabledWalletsRdns={disabledWalletRdns}
-                              onGetWallet={WalletStorage.get}
-                              onClearWallet={WalletStorage.clear}
-                              onSaveWallet={WalletStorage.save}
-                            >
-                              <ExtensionPopupProvider>
-                                <ExtensionSettingsProvider>
-                                  <TwitterScrapingContextProvider>
-                                    <WarpcastScrapingContextProvider>
-                                      <SupercastScrapingContextProvider>
-                                        {children}
-                                      </SupercastScrapingContextProvider>
-                                    </WarpcastScrapingContextProvider>
-                                  </TwitterScrapingContextProvider>
-                                </ExtensionSettingsProvider>
-                              </ExtensionPopupProvider>
-                            </WalletContextProvider>
-                          </NotificationsProvider>
+                          <AuthTokenContextProvider
+                            onGetAuthToken={AuthTokenStorage.get}
+                            onClearAuthToken={AuthTokenStorage.clear}
+                            onSaveAuthToken={AuthTokenStorage.save}
+                          >
+                            <NotificationsProvider>
+                              <WalletContextProvider
+                                disabledWalletsRdns={disabledWalletRdns}
+                                onGetWallet={WalletStorage.get}
+                                onClearWallet={WalletStorage.clear}
+                                onSaveWallet={WalletStorage.save}
+                              >
+                                <ExtensionPopupProvider>
+                                  <ExtensionSettingsProvider>
+                                    <TwitterScrapingContextProvider>
+                                      <WarpcastScrapingContextProvider>
+                                        <SupercastScrapingContextProvider>
+                                          {children}
+                                        </SupercastScrapingContextProvider>
+                                      </WarpcastScrapingContextProvider>
+                                    </TwitterScrapingContextProvider>
+                                  </ExtensionSettingsProvider>
+                                </ExtensionPopupProvider>
+                              </WalletContextProvider>
+                            </NotificationsProvider>
+                          </AuthTokenContextProvider>
                         </NiceModal.Provider>
                       </QueryProvider>
                     </TailwindProvider>

--- a/apps/extension/src/shared/extension/auth-token-manager.ts
+++ b/apps/extension/src/shared/extension/auth-token-manager.ts
@@ -1,0 +1,28 @@
+import { StoredAuthToken } from './types';
+
+export const AuthTokenManager = {
+  saveAuthToken(authToken: StoredAuthToken) {
+    return chrome.storage.local.set({
+      'authentication-token': JSON.stringify(authToken),
+    });
+  },
+
+  getAuthToken(): Promise<StoredAuthToken> {
+    return new Promise((resolve) => {
+      void chrome.storage.local
+        .get('authentication-token')
+        .then((storedAuthTokenRaw) => {
+          const storedAuthToken = storedAuthTokenRaw['authentication-token']
+            ? (JSON.parse(
+                storedAuthTokenRaw['authentication-token'],
+              ) as StoredAuthToken)
+            : undefined;
+          return resolve(storedAuthToken);
+        });
+    });
+  },
+
+  clearAuthToken() {
+    return chrome.storage.local.remove('authentication-token');
+  },
+};

--- a/apps/extension/src/shared/extension/context/auth-token-context.tsx
+++ b/apps/extension/src/shared/extension/context/auth-token-context.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { createContextHook } from 'shared/ui';
+
+import { StoredAuthToken } from '../types';
+
+type AuthTokenContextValue = {
+  authToken?: StoredAuthToken;
+  saveAuthToken: (payload: StoredAuthToken) => void;
+  clearAuthToken: () => void;
+};
+
+const AuthTokenContext = createContext<AuthTokenContextValue | undefined>(
+  undefined,
+);
+
+export const AuthTokenContextProvider = ({
+  children,
+  onClearAuthToken,
+  onGetAuthToken,
+  onSaveAuthToken,
+}: {
+  children: ReactNode;
+  onClearAuthToken?: () => void;
+  onGetAuthToken?: () => Promise<StoredAuthToken>;
+  onSaveAuthToken?: (payload: StoredAuthToken) => void;
+}) => {
+  const [authToken, setAuthToken] = useState<StoredAuthToken>();
+
+  useEffect(() => {
+    const fetchAuthToken = async () => {
+      const token = await onGetAuthToken?.();
+      setAuthToken(token);
+    };
+
+    void fetchAuthToken();
+  }, [onGetAuthToken]);
+
+  const saveAuthToken = useCallback(
+    (payload: StoredAuthToken) => {
+      onSaveAuthToken?.(payload);
+      setAuthToken(payload);
+    },
+    [onSaveAuthToken],
+  );
+
+  const clearAuthToken = useCallback(() => {
+    onClearAuthToken?.();
+    setAuthToken(undefined);
+  }, [onClearAuthToken]);
+
+  const contextValue = useMemo(() => {
+    return {
+      authToken,
+      saveAuthToken,
+      clearAuthToken,
+    };
+  }, [authToken, saveAuthToken, clearAuthToken]);
+
+  return (
+    <AuthTokenContext.Provider value={contextValue}>
+      {children}
+    </AuthTokenContext.Provider>
+  );
+};
+
+export const useAuthToken = createContextHook(AuthTokenContext);

--- a/apps/extension/src/shared/extension/context/auth-token-context.tsx
+++ b/apps/extension/src/shared/extension/context/auth-token-context.tsx
@@ -17,6 +17,7 @@ type AuthTokenContextValue = {
   authToken?: StoredAuthToken;
   saveAuthToken: (payload: StoredAuthToken) => void;
   clearAuthToken: () => void;
+  getAuthToken: () => Promise<StoredAuthToken>;
 };
 
 const AuthTokenContext = createContext<AuthTokenContextValue | undefined>(
@@ -45,6 +46,10 @@ export const AuthTokenContextProvider = ({
     void fetchAuthToken();
   }, [onGetAuthToken]);
 
+  const getAuthToken = useCallback(async () => {
+    return onGetAuthToken?.();
+  }, [onGetAuthToken]);
+
   const saveAuthToken = useCallback(
     (payload: StoredAuthToken) => {
       onSaveAuthToken?.(payload);
@@ -61,10 +66,11 @@ export const AuthTokenContextProvider = ({
   const contextValue = useMemo(() => {
     return {
       authToken,
+      getAuthToken,
       saveAuthToken,
       clearAuthToken,
     };
-  }, [authToken, saveAuthToken, clearAuthToken]);
+  }, [authToken, getAuthToken, saveAuthToken, clearAuthToken]);
 
   return (
     <AuthTokenContext.Provider value={contextValue}>

--- a/apps/extension/src/shared/extension/context/index.ts
+++ b/apps/extension/src/shared/extension/context/index.ts
@@ -3,3 +3,4 @@ export {
   useExtensionPopup,
   ExtensionPopupProvider,
 } from './extension-popup-context';
+export { useAuthToken, AuthTokenContextProvider } from './auth-token-context';

--- a/apps/extension/src/shared/extension/index.ts
+++ b/apps/extension/src/shared/extension/index.ts
@@ -10,6 +10,8 @@ export {
 export type { PopupRoute } from './constants';
 export {
   ExtensionSettingsProvider,
+  AuthTokenContextProvider,
+  useAuthToken,
   useExtensionSettings,
   ExtensionPopupProvider,
   useExtensionPopup,
@@ -18,5 +20,6 @@ export {
   COMMAND_MAP as EXTENSION_COMMAND_MAP,
   GetServiceStatusCommand,
 } from './commands';
-export type { ExtensionSettingName } from './types';
+export type { ExtensionSettingName, StoredAuthToken } from './types';
 export { ExtensionSettingsManager } from './extension-settings-manager';
+export { AuthTokenManager } from './auth-token-manager';

--- a/apps/extension/src/shared/extension/types.ts
+++ b/apps/extension/src/shared/extension/types.ts
@@ -18,3 +18,5 @@ export interface StoredWallet {
   account: Hex;
   providerRdns: string;
 }
+
+export type StoredAuthToken = string | undefined;

--- a/apps/extension/src/shared/web3/index.ts
+++ b/apps/extension/src/shared/web3/index.ts
@@ -35,4 +35,4 @@ export { AGORA_LOGO } from './logos';
 export { SNAPSHOT_LOGO } from './logos';
 export { TALLY_LOGO } from './logos';
 export { TransactionRevertedError } from './errors';
-export { WalletStorage } from './storage';
+export { WalletStorage, AuthTokenStorage } from './storage';

--- a/apps/extension/src/shared/web3/storage.ts
+++ b/apps/extension/src/shared/web3/storage.ts
@@ -7,6 +7,8 @@ interface StoredWallet {
   providerRdns: string;
 }
 
+type StoredAuthToken = string | undefined;
+
 export class WalletStorage {
   public static get(): Promise<StoredWallet | undefined> {
     return new Promise((resolve) => {
@@ -33,6 +35,36 @@ export class WalletStorage {
   public static clear() {
     window.postMessage({
       type: 'CLEAR_WALLET',
+    });
+  }
+}
+
+export class AuthTokenStorage {
+  public static get(): Promise<StoredAuthToken> {
+    return new Promise((resolve) => {
+      window.postMessage({
+        type: 'GET_AUTH_TOKEN',
+      });
+
+      onWindowMessage<StoredAuthToken>(
+        'GET_AUTH_TOKEN_RESPONSE',
+        (maybeAuthToken) => {
+          resolve(maybeAuthToken);
+        },
+      );
+    });
+  }
+
+  public static save(payload: StoredAuthToken) {
+    window.postMessage({
+      type: 'SAVE_AUTH_TOKEN',
+      detail: payload,
+    });
+  }
+
+  public static clear() {
+    window.postMessage({
+      type: 'CLEAR_AUTH_TOKEN',
     });
   }
 }


### PR DESCRIPTION
Moved authToken from localStorage to context provider. Now we store authToken in extension context to have access to it across all tabs.

Updated /subscribe and /unsubscribe code to always have latest state of authToken.

Updated /get-quote in use-exchanger to also use latest state of authToken.