### PR TITLE
fix: Temporarily remove api key

### DIFF
--- a/apps/copilot-api/index.ts
+++ b/apps/copilot-api/index.ts
@@ -91,7 +91,7 @@ app.use('/', defaultRoutes);
 // Initialize LiFi SDK
 createConfig({
   integrator: process.env.LIFI_INTEGRATOR_STRING ?? 'IDRISS',
-  apiKey: process.env.LIFI_API_KEY,
+  // apiKey: process.env.LIFI_API_KEY,
 });
 
 server.listen(PORT, () => {


### PR DESCRIPTION
## Overview
Commented line  94 of apps/copilot-api/index.ts so that requests to the Li.Fi API are not hitting limits now (until repeated requests to /get-quote are fixed).