### PR TITLE
fix(copilot): Change test-swap address to DEGEN on Base

### DIFF
--- a/apps/copilot-api/routes/index.ts
+++ b/apps/copilot-api/routes/index.ts
@@ -63,9 +63,9 @@ router.get('/test-swap/:subscriberId', async (req, res) => {
     from: '0x4a3755eb99ae8b22aafb8f16f0c51cf68eb60b85',
     to: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
     tokenIn: {
-      address: '0xb23d80f5fefcddaa212212f028021b41ded428cf',
-      symbol: 'PRIME',
-      amount: 0.33961864050271173,
+      address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+      symbol: 'DEGEN',
+      amount: 357.09,
       decimals: 18,
       network: 'BASE',
     },


### PR DESCRIPTION
## Overview
Changed since PRIME address was wrong (using mainnet 0xb23d80f5fefcddaa212212f028021b41ded428cf). New address is for DEGEN 0x4ed4e862860bed51a9570b96d89af5e1b0efefed, and conversion ratio was updated too (0.001 WETH to ~357 DEGEN)