### PR TITLE
Fix: Current token list (coingecko) does not have Base tokens.

### DIFF
--- a/apps/extension/src/application/trading-copilot/commands/get-tokens-list.ts
+++ b/apps/extension/src/application/trading-copilot/commands/get-tokens-list.ts
@@ -7,7 +7,7 @@ import {
 } from 'shared/messaging';
 
 type Response = {
-  tokens: Record<string, string>[];
+  items: Record<string, string>[];
 };
 
 export class GetTokensListCommand extends Command<void, Response> {

--- a/apps/extension/src/application/trading-copilot/commands/get-tokens-list.ts
+++ b/apps/extension/src/application/trading-copilot/commands/get-tokens-list.ts
@@ -21,7 +21,7 @@ export class GetTokensListCommand extends Command<void, Response> {
   async handle() {
     try {
       const response = await fetch(
-        'https://tokens.coingecko.com/uniswap/all.json',
+        'https://base.blockscout.com/api/v2/tokens',
         {
           headers: {
             'Content-Type': 'application/json',

--- a/apps/extension/src/final/notifications-popup/notifications-popup.tsx
+++ b/apps/extension/src/final/notifications-popup/notifications-popup.tsx
@@ -85,7 +85,7 @@ const NotificationsPopupContent = ({
 
         const tokenAddress = data.tokenIn.address;
 
-        const tokens = tokensList?.tokens ?? [];
+        const tokens = tokensList?.items ?? [];
 
         const tokenData =
           tokens.find((t) => {
@@ -98,7 +98,7 @@ const NotificationsPopupContent = ({
           tokenAddress.toLowerCase() === IDRISS_TOKEN_ADDRESS
             ? 'IdrissToken'
             : ((await tokenIconMutation.mutateAsync({
-                tokeURI: tokenData?.logoURI ?? '',
+                tokeURI: tokenData?.icon_url ?? '',
               })) ?? '');
         selectedTokenImage.current = tokenImage;
 

--- a/apps/extension/src/final/notifications-popup/utils/token-icon.tsx
+++ b/apps/extension/src/final/notifications-popup/utils/token-icon.tsx
@@ -17,7 +17,7 @@ export const TokenIcon: React.FC<TokenIconProperties> = ({
       if (tokenImage === 'IdrissToken') {
         setIcon(<Icon name="IdrissToken" size={24} className="size-6" />);
       } else {
-        if (tokenData) {
+        if (tokenData && tokenImage) {
           setIcon(
             <img src={tokenImage} alt={tokenData.symbol} className="size-6" />,
           );


### PR DESCRIPTION
## Overview
Coingecko token list that we were using to fetch images and token symbols do not include tokens on the Base chain (which is the only chain we support not). This was refactored to use blockscout's specific Base token list, which has a little different format, thus some changes were required on `notifications-popup.tsx`.

Also added a check for when tokenImage (src string we use for the token icon displayed on the notification) is not present.