### PR TITLE
fix(copilot): Tooltips cannot display div inside p

### DIFF
--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -227,7 +227,7 @@ const TradingCopilotDialogContent = ({
           }
         />
         <div className="flex w-full flex-col">
-          <p className="break-all text-label3 text-neutral-900">
+          <div className="break-all text-label3 text-neutral-900">
             {isAddress(userName) ? (
               <TradingCopilotTooltip content={userName}>
                 {getShortWalletHex(userName)}
@@ -272,7 +272,7 @@ const TradingCopilotDialogContent = ({
                 <TokenIcon tokenImage={tokenImage} tokenData={tokenData} />
               </span>
             </span>
-          </p>
+          </div>
           <p className="text-body6 text-mint-700">
             <TimeDifferenceCounter timestamp={dialog.timestamp} text="ago" />
           </p>
@@ -370,7 +370,7 @@ const TradingCopilotWalletBalance = ({ wallet }: WalletBalanceProperties) => {
     roundToSignificantFiguresForCopilotTrading(Number(balanceQuery.data), 2);
 
   return (
-    <p className="text-body6 text-neutral-500">
+    <div className="text-body6 text-neutral-500">
       Balance:{' '}
       <TradingCopilotTooltip content={getWholeNumber(balanceQuery.data)}>
         {zerosIndex ? (
@@ -386,7 +386,7 @@ const TradingCopilotWalletBalance = ({ wallet }: WalletBalanceProperties) => {
         )}
       </TradingCopilotTooltip>{' '}
       ETH
-    </p>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Overview
We were getting error: `validateDOMNesting(...): <div> cannot appear as a descendant of <p>` when clicking on Copy and showing the copy trade modal/widget

## How it was fixed
Replaced the tags where TradingCopilotTooltip component was wrapped in paragraph `<p>` tags for `<div>` tags