### PR TITLE
Refactor: Use new copilot token list from LiFi

### DIFF
--- a/apps/extension/src/application/trading-copilot/commands/get-tokens-list.ts
+++ b/apps/extension/src/application/trading-copilot/commands/get-tokens-list.ts
@@ -7,7 +7,9 @@ import {
 } from 'shared/messaging';
 
 type Response = {
-  items: Record<string, string>[];
+  tokens: {
+    [chainId: string]: Record<string, string>[]; // TODO: Correctly type record depending on API response
+  }
 };
 
 export class GetTokensListCommand extends Command<void, Response> {
@@ -21,7 +23,7 @@ export class GetTokensListCommand extends Command<void, Response> {
   async handle() {
     try {
       const response = await fetch(
-        'https://base.blockscout.com/api/v2/tokens',
+        'https://li.quest/v1/tokens?chains=bas',
         {
           headers: {
             'Content-Type': 'application/json',

--- a/apps/extension/src/final/notifications-popup/notifications-popup.tsx
+++ b/apps/extension/src/final/notifications-popup/notifications-popup.tsx
@@ -17,6 +17,7 @@ import { GetImageCommand } from 'shared/utils';
 
 import { TradingCopilotToast, TradingCopilotDialog } from './components';
 import { Properties, ContentProperties } from './notifications-popup.types';
+import { CHAIN } from 'shared/web3';
 
 const IDRISS_TOKEN_ADDRESS = '0x000096630066820566162c94874a776532705231';
 
@@ -85,7 +86,8 @@ const NotificationsPopupContent = ({
 
         const tokenAddress = data.tokenIn.address;
 
-        const tokens = tokensList?.items ?? [];
+        // Filter token list by chain (Base)
+        const tokens = tokensList?.tokens?.[CHAIN.BASE.id] ?? [];
 
         const tokenData =
           tokens.find((t) => {
@@ -98,7 +100,7 @@ const NotificationsPopupContent = ({
           tokenAddress.toLowerCase() === IDRISS_TOKEN_ADDRESS
             ? 'IdrissToken'
             : ((await tokenIconMutation.mutateAsync({
-                tokeURI: tokenData?.icon_url ?? '',
+                tokeURI: tokenData?.logoURI ?? '',
               })) ?? '');
         selectedTokenImage.current = tokenImage;
 


### PR DESCRIPTION
## Overview
Previous token list was too short on tokens (only had 50). This new one includes more than 800 tokens.

## How it was solved
Used the new endpoint `https://li.quest/v1/tokens?chains=bas` (notice the filter with Base chain "chains=bas")

## How to test it
Execute any trade on a subscribed address on Jumper exchange with any Base token, it should reflect and see token icons on the IDRISS copilot notification. I tested $MISSER (token address `0x0718F45Bbf4781cE891e4e18182F025725F0fc95`)