### PR TITLE
fix(copilot): Tooltip DOM error, div inside p tag.

### DIFF
--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -226,7 +226,7 @@ const TradingCopilotDialogContent = ({
           }
         />
         <div className="flex w-full flex-col">
-          <div className="break-all text-label3 text-neutral-900">
+          <p className="break-all text-label3 text-neutral-900">
             {isAddress(userName) ? (
               <TradingCopilotTooltip content={userName}>
                 {getShortWalletHex(userName)}
@@ -271,7 +271,7 @@ const TradingCopilotDialogContent = ({
                 <TokenIcon tokenImage={tokenImage} tokenData={tokenData} />
               </span>
             </span>
-          </div>
+          </p>
           <p className="text-body6 text-mint-700">
             <TimeDifferenceCounter timestamp={dialog.timestamp} text="ago" />
           </p>
@@ -369,7 +369,7 @@ const TradingCopilotWalletBalance = ({ wallet }: WalletBalanceProperties) => {
     roundToSignificantFiguresForCopilotTrading(Number(balanceQuery.data), 2);
 
   return (
-    <div className="text-body6 text-neutral-500">
+    <p className="text-body6 text-neutral-500">
       Balance:{' '}
       <TradingCopilotTooltip content={getWholeNumber(balanceQuery.data)}>
         {zerosIndex ? (
@@ -385,7 +385,7 @@ const TradingCopilotWalletBalance = ({ wallet }: WalletBalanceProperties) => {
         )}
       </TradingCopilotTooltip>{' '}
       ETH
-    </div>
+    </p>
   );
 };
 

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-tooltip/trading-copilot-tooltip.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-tooltip/trading-copilot-tooltip.tsx
@@ -18,17 +18,17 @@ export const TradingCopilotTooltip = ({
   };
 
   return (
-    <div
+    <span
       className="relative inline-block"
       onMouseEnter={showModal}
       onMouseLeave={hideModal}
     >
-      <div className="inline-block cursor-default">{children}</div>
-      <div
+      <span className="inline-block cursor-default">{children}</span>
+      <span
         className={`custom-transition absolute left-1/2 z-10 w-max -translate-x-1/2 -translate-y-12 rounded-lg bg-black px-2 py-0.5 text-xs text-white ease-in-out ${isVisible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'} ${className}`}
       >
         {content}
-      </div>
-    </div>
+      </span>
+    </span>
   );
 };


### PR DESCRIPTION
## Overview
Finally gets rid of some other instances of `validateDOMNesting(...): <div> cannot appear as a descendant of <p>` with a better solution

## How it was solved
Instead of modifying all current and future wrappers of tooltip I just switched the Tooltip component to be a span instead of a div, since spans can be contained in every tag and even inside span tags.