### PR TITLE
fix: Repeated requests to dao-twitter-handles endpoint.

### DIFF
--- a/apps/extension/src/host/twitter/hooks/use-handle-to-username-map.ts
+++ b/apps/extension/src/host/twitter/hooks/use-handle-to-username-map.ts
@@ -15,7 +15,7 @@ export const useHandleToUsernameMap = ({
     select: (handles) => {
       return handles[application.toLowerCase()] ?? {};
     },
-    retryDelay: 60000,
+    retryDelay: 60_000,
     staleTime: Number.POSITIVE_INFINITY,
     enabled,
   });

--- a/apps/extension/src/host/twitter/hooks/use-handle-to-username-map.ts
+++ b/apps/extension/src/host/twitter/hooks/use-handle-to-username-map.ts
@@ -15,6 +15,8 @@ export const useHandleToUsernameMap = ({
     select: (handles) => {
       return handles[application.toLowerCase()] ?? {};
     },
+    retryDelay: 60000,
+    staleTime: Number.POSITIVE_INFINITY,
     enabled,
   });
 };


### PR DESCRIPTION
## Overview
Extension was sending too many requests (sometimes in bratches of four) to api endpoint `/dao-twitter-handles`. Due to rate limits most times these requests are failing and retrying.

## How it was solved
Added staleTime positive infinity like other requests and a retryDelay of 1 minute both in `use-handle-username-map.ts`, since this is not a time sensitive fetch or update. These are both parameters of useQuery from React, which is what our command abstraction is using under the hood.