### PR TITLE
feat: enable ens names in OBS page URL params 

### DIFF
--- a/apps/main-landing/src/app/creators/obs/page.tsx
+++ b/apps/main-landing/src/app/creators/obs/page.tsx
@@ -35,7 +35,6 @@ const FETCH_INTERVAL = 5000;
 export default function Obs() {
   const router = useRouter();
   const searchParameters = useSearchParams();
-  const address = searchParameters.get('address');
   const [resolvedAddress, setResolvedAddress] = useState<Hex | null>(null);
   const [donationsQueue, setDonationsQueue] = useState<
     DonationNotificationProperties[]
@@ -44,6 +43,13 @@ export default function Obs() {
 
   useEffect(() => {
     const resolveAddress = async () => {
+      let address = searchParameters.get('streamerAddress');
+      const newStreamerAddress = searchParameters.get('address');
+
+      if (newStreamerAddress) {
+        address = newStreamerAddress;
+      }
+
       if (!address) {
         router.push('/creators');
         return;
@@ -71,7 +77,7 @@ export default function Obs() {
       console.error('Unexpected error resolving address:', error);
       router.push('/creators');
     });
-  }, [address, router]);
+  }, [searchParameters, router]);
 
   const displayNextDonation = useCallback(() => {
     setIsDisplayingDonation(true);


### PR DESCRIPTION
## Overview

- support both ens names and hex addresses in the creator's OBS overlay page URL params

- add resolveEnsToHex utils function

- check both address and streamerAddress URL params (to handle legacy links)

### Proof

https://github.com/user-attachments/assets/dd22c39b-1bff-4e12-8841-de6420562e51

#### blocks range I've tested with
![image](https://github.com/user-attachments/assets/3d5da21a-ecb7-409f-b65d-6ef80a13245e)
