### PR TITLE
fix: Linter warnings on donation-notification and use-geo-location

### DIFF
--- a/apps/main-landing/.eslintrc.cjs
+++ b/apps/main-landing/.eslintrc.cjs
@@ -17,9 +17,11 @@ module.exports = {
         '**/.*.mjs',
         '**/*.d.ts',
         'src/app/**/*',
+        'src/components/**/*',
       ],
       rules: {
         'import/no-default-export': 'off',
+        '@next/next/no-img-element': 'off',
       },
     },
   ],

--- a/apps/main-landing/next.config.ts
+++ b/apps/main-landing/next.config.ts
@@ -167,5 +167,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-// eslint-disable-next-line import/no-default-export
 export default withBundleAnalyzer({ enabled: false })(nextConfig);

--- a/apps/main-landing/src/app/creators/banner/page.tsx
+++ b/apps/main-landing/src/app/creators/banner/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 import { Button } from '@idriss-xyz/ui/button';
 import { IconButton } from '@idriss-xyz/ui/icon-button';

--- a/apps/main-landing/src/app/creators/donate/components/chain-select.tsx
+++ b/apps/main-landing/src/app/creators/donate/components/chain-select.tsx
@@ -47,7 +47,6 @@ const optionsFrom = (
   return {
     label: chain.name,
     value: chain.id,
-    // eslint-disable-next-line @next/next/no-img-element
     prefix: <img src={chain.logo} className="size-6 rounded-full" alt="" />,
     suffix: renderSuffix?.(chain.id),
   };

--- a/apps/main-landing/src/app/creators/donate/components/token-select.tsx
+++ b/apps/main-landing/src/app/creators/donate/components/token-select.tsx
@@ -40,7 +40,6 @@ const optionsFrom = (tokens: Token[]) => {
       label: token.name,
       value: token.symbol,
       prefix: (
-        // eslint-disable-next-line @next/next/no-img-element
         <img
           src={token.logo}
           className="size-6 rounded-full"

--- a/apps/main-landing/src/app/creators/donate/content.tsx
+++ b/apps/main-landing/src/app/creators/donate/content.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 import { Form } from '@idriss-xyz/ui/form';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';

--- a/apps/main-landing/src/app/creators/donate/page.tsx
+++ b/apps/main-landing/src/app/creators/donate/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import { Button } from '@idriss-xyz/ui/button';
 import { CREATORS_LINK } from '@idriss-xyz/constants';
 

--- a/apps/main-landing/src/app/creators/obs/components/donation-notification.tsx
+++ b/apps/main-landing/src/app/creators/obs/components/donation-notification.tsx
@@ -59,11 +59,11 @@ const DonationNotification = ({
         />
       </div>
       <div>
-        <p id="baseInfo" className="text-neutral-900 ml-3 text-xl font-bold">
+        <p id="baseInfo" className="ml-3 text-xl font-bold text-neutral-900">
           {`${donor} sent $${amount}`}
         </p>
         {message && (
-          <p id="message" className="text-neutral-900 ml-3 text-lg font-medium">
+          <p id="message" className="ml-3 text-lg font-medium text-neutral-900">
             {message}
           </p>
         )}

--- a/apps/main-landing/src/app/creators/obs/components/donation-notification.tsx
+++ b/apps/main-landing/src/app/creators/obs/components/donation-notification.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useMemo, type CSSProperties } from 'react';
-import Image from 'next/image';
 
 import { IDRISS_ICON_CIRCLE, NOTIFICATION_SOUND } from '@/assets';
 
@@ -52,7 +51,7 @@ const DonationNotification = ({
       }`}
     >
       <div className="flex size-14 items-center justify-center">
-        <Image
+        <img
           className="h-14 w-auto rounded-full"
           src={customIcon}
           alt="IDRISS logo"

--- a/apps/main-landing/src/app/creators/obs/components/donation-notification.tsx
+++ b/apps/main-landing/src/app/creators/obs/components/donation-notification.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, type CSSProperties } from 'react';
+import Image from 'next/image';
 
 import { IDRISS_ICON_CIRCLE, NOTIFICATION_SOUND } from '@/assets';
 
@@ -46,23 +47,23 @@ const DonationNotification = ({
       aria-live="polite"
       nonce={txnHash}
       style={style}
-      className={`absolute left-0 top-0 flex items-center rounded-r-md bg-opacity-80 p-4 transition-opacity duration-1000 ${bgColor} ${
+      className={`absolute left-0 top-0 flex items-center rounded-r-md p-4 transition-opacity duration-1000 ${bgColor} ${
         showNotification ? 'opacity-100' : 'opacity-0'
       }`}
     >
       <div className="flex size-14 items-center justify-center">
-        <img
+        <Image
           className="h-14 w-auto rounded-full"
           src={customIcon}
           alt="IDRISS logo"
         />
       </div>
       <div>
-        <p id="baseInfo" className="text-gray-900 ml-3 text-xl font-bold">
+        <p id="baseInfo" className="text-neutral-900 ml-3 text-xl font-bold">
           {`${donor} sent $${amount}`}
         </p>
         {message && (
-          <p id="message" className="text-gray-900 ml-3 text-lg font-medium">
+          <p id="message" className="text-neutral-900 ml-3 text-lg font-medium">
             {message}
           </p>
         )}

--- a/apps/main-landing/src/app/creators/page.tsx
+++ b/apps/main-landing/src/app/creators/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 import { Form } from '@idriss-xyz/ui/form';
 import { Button } from '@idriss-xyz/ui/button';

--- a/apps/main-landing/src/components/footer/footer.tsx
+++ b/apps/main-landing/src/components/footer/footer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 import { Link } from '@idriss-xyz/ui/link';
 import { Button } from '@idriss-xyz/ui/button';

--- a/apps/main-landing/src/components/hero-section/hero-section.tsx
+++ b/apps/main-landing/src/components/hero-section/hero-section.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 import { Button } from '@idriss-xyz/ui/button';
 import { classes } from '@idriss-xyz/ui/utils';

--- a/apps/main-landing/src/components/image-sequencer/image-sequencer.tsx
+++ b/apps/main-landing/src/components/image-sequencer/image-sequencer.tsx
@@ -1,6 +1,4 @@
 'use client';
-/* eslint-disable @next/next/no-img-element */
-
 import { classes } from '@idriss-xyz/ui/utils';
 import { useEffect, useRef, useState } from 'react';
 

--- a/apps/main-landing/src/components/products-section/components/product-section.tsx
+++ b/apps/main-landing/src/components/products-section/components/product-section.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 import { Icon, IconName } from '@idriss-xyz/ui/icon';
 import { ReactNode } from 'react';

--- a/apps/main-landing/src/components/superpowers-section/superpowers-section.tsx
+++ b/apps/main-landing/src/components/superpowers-section/superpowers-section.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import { Button } from '@idriss-xyz/ui/button';
 import {
   CHROME_EXTENSION_LINK,

--- a/apps/main-landing/src/components/token-section/hooks/use-geo-location.ts
+++ b/apps/main-landing/src/components/token-section/hooks/use-geo-location.ts
@@ -104,12 +104,14 @@ export const useGeoLocation = () => {
       }
     };
 
+    const currentController = controller.current;
+
     fetchGeoLocation().catch((error) => {
       console.error('Unexpected error in fetching geolocation:', error);
     });
 
     return () => {
-      controller.current.abort();
+      currentController.abort();
     };
   }, []);
 

--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 'use client';
 
 import { Button } from '@idriss-xyz/ui/button';

--- a/apps/main-landing/src/components/top-bar/top-bar.tsx
+++ b/apps/main-landing/src/components/top-bar/top-bar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import Link from 'next/link';
 
 import { Navigation } from './components';


### PR DESCRIPTION
## Overview

Removed these warnings from running linter:
```
@idriss-xyz/main-landing:lint:fix: ./src/app/creators/obs/components/donation-notification.tsx
@idriss-xyz/main-landing:lint:fix: 49:7  Warning: Classname 'bg-opacity-80' should be replaced by an opacity suffix (eg. '/80')  tailwindcss/migration-from-tailwind-2
@idriss-xyz/main-landing:lint:fix: 54:9  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
@idriss-xyz/main-landing:lint:fix: 61:26  Warning: Classname 'text-gray-900' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
@idriss-xyz/main-landing:lint:fix: 65:27  Warning: Classname 'text-gray-900' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
@idriss-xyz/main-landing:lint:fix: 
@idriss-xyz/main-landing:lint:fix: ./src/components/token-section/hooks/use-geo-location.ts
@idriss-xyz/main-landing:lint:fix: 112:18  Warning: The ref value 'controller.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'controller.current' to a variable inside the effect, and use that variable in the cleanup function.  react-hooks/exhaustive-deps
```