### PR TITLE
fix: added filtering of duplicated users from scraper in widgets

### DIFF
--- a/apps/extension/src/final/hooks/use-user-widgets.ts
+++ b/apps/extension/src/final/hooks/use-user-widgets.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import { useGitcoinDonationWidgetsData } from 'application/gitcoin';
 import { useIdrissSendWidgetsData } from 'application/idriss-send';
 import { useExtensionSettings } from 'shared/extension';
@@ -16,7 +18,9 @@ export const useUserWidgets = () => {
   const isFarcaster = isSupercast || isWarpcast;
   const { extensionSettings } = useExtensionSettings();
 
-  const { users } = useScraping();
+  const { users: scrapedUsers } = useScraping();
+
+  const users = _.uniqBy(scrapedUsers, 'nodeId');
 
   const idrissSendEnabled =
     applicationsStatus.idrissSend && extensionSettings['idriss-send-enabled'];


### PR DESCRIPTION
Fixed problem with duplicated widgets. Fix work as expected on farcaster. We don't had any reports about same problem on twitter or supercast - but even if it did, it shouldn't happen from now.
