### PR TITLE
feat: authorize test-swap via secret key from env & add date timestamp for subscribers and subscriptions

### DIFF
--- a/apps/copilot-api/entities/subscribers.entity.ts
+++ b/apps/copilot-api/entities/subscribers.entity.ts
@@ -1,7 +1,10 @@
-import { Entity, PrimaryColumn } from 'typeorm';
+import { CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('subscribers')
 export class SubscribersEntity {
   @PrimaryColumn({ type: 'text', name: 'subscriber_id' })
   readonly subscriber_id!: string;
+
+  @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
+  readonly created_at!: Date;
 }

--- a/apps/copilot-api/entities/subscribtions.entity.ts
+++ b/apps/copilot-api/entities/subscribtions.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
 import { SubscribersEntity } from './subscribers.entity';
 import { AddressesEntity } from './addresses.entity';
 
@@ -12,6 +19,9 @@ export class SubscriptionsEntity {
 
   @Column({ type: 'integer', name: 'fid', nullable: true })
   readonly fid!: number;
+
+  @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
+  readonly created_at!: Date;
 
   @ManyToOne(() => SubscribersEntity)
   @JoinColumn({ name: 'subscriber_id' })

--- a/apps/copilot-api/routes/index.ts
+++ b/apps/copilot-api/routes/index.ts
@@ -75,7 +75,13 @@ router.post('/unsubscribe', verifyToken(), async (req, res) => {
 });
 
 router.get('/test-swap/:subscriberId', async (req, res) => {
-  const { subscriberId } = req.params || {};
+  const { subscriberId } = req.params;
+  const { secret } = req.query;
+
+  if (secret !== process.env.API_SECRET) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
 
   // Validate swapData here if necessary
   if (!testSwapData || !testSwapData.isComplete) {

--- a/apps/copilot-api/services/subscriptionManager.ts
+++ b/apps/copilot-api/services/subscriptionManager.ts
@@ -263,6 +263,7 @@ export const getSubscriptionsDetails = async (
   return res.map((subscription: SubscriptionsEntity) => ({
     address: subscription.address,
     fid: subscription.fid,
+    createdAt: subscription.created_at.getTime(),
   }));
 };
 

--- a/apps/copilot-api/types/services.types.ts
+++ b/apps/copilot-api/types/services.types.ts
@@ -9,6 +9,7 @@ export interface WebhookDataInterface {
 export interface SubscriptionsDetailsInterface {
   address: string;
   fid: number | null;
+  createdAt: number;
 }
 
 interface CachedTransaction {

--- a/apps/extension/src/application/trading-copilot/types.ts
+++ b/apps/extension/src/application/trading-copilot/types.ts
@@ -30,6 +30,7 @@ export type SubscriptionsPayload = {
 export type SubscriptionResponse = {
   address: Hex;
   fid?: number | null;
+  createdAt: number;
 };
 
 export type SubscriptionsResponse = {


### PR DESCRIPTION
Added authorization via secret key from env variables. We need to add token to .env variables and then pass it in url of test-swap.

My example url of test swap:
http://localhost:8080/test-swap/0x8637AF884f71ef0e60851940E816dfE163599840?secret=5ePj3e77NM

Added timestamp for subscribers and subscriptions in backend, and also passed it to frontend.