### PR TITLE
feat(airdrop): Add check different wallet, change eligible header

### DIFF
--- a/apps/main-landing/src/app/claim/components/claim/claim-content.tsx
+++ b/apps/main-landing/src/app/claim/components/claim/claim-content.tsx
@@ -6,6 +6,7 @@ import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
 import { classes } from '@idriss-xyz/ui/utils';
 import { AIRDROP_DOCS_LINK, COINMARKETCAP_LINK } from '@idriss-xyz/constants';
 import { Icon } from '@idriss-xyz/ui/icon';
+import { Link } from '@idriss-xyz/ui/link';
 
 import { GeoConditionalButton } from '@/components/token-section/components/geo-conditional-button';
 
@@ -18,7 +19,6 @@ import {
 } from './constants';
 import { IdrissUserCriteriaDescription } from './components/idriss-user-criteria-description';
 import { PartnerMemberDescription } from './components/partner-member-description';
-import { Link } from '@idriss-xyz/ui/link';
 
 export const ClaimContent = () => {
   const { eligibilityData, setCurrentContent } = useClaimPage();
@@ -101,11 +101,11 @@ export const ClaimContent = () => {
             </Button>
           }
         />
-        <div className='flex w-full items-center justify-center mt-5'>
+        <div className="mt-5 flex w-full items-center justify-center">
           <span className="text-body5 text-neutralGreen-900">
             <Link
               size="medium"
-              className="text-body5 lg:text-body5 cursor-pointer"
+              className="cursor-pointer text-body5 lg:text-body5"
               onClick={() => {
                 setCurrentContent('check-eligibility');
               }}

--- a/apps/main-landing/src/app/claim/components/claim/claim-content.tsx
+++ b/apps/main-landing/src/app/claim/components/claim/claim-content.tsx
@@ -18,6 +18,7 @@ import {
 } from './constants';
 import { IdrissUserCriteriaDescription } from './components/idriss-user-criteria-description';
 import { PartnerMemberDescription } from './components/partner-member-description';
+import { Link } from '@idriss-xyz/ui/link';
 
 export const ClaimContent = () => {
   const { eligibilityData, setCurrentContent } = useClaimPage();
@@ -42,7 +43,7 @@ export const ClaimContent = () => {
       />
       <div className="flex w-[459px] flex-col">
         <div className="flex flex-col items-start gap-10">
-          <span className="text-heading3">YOU’RE ELIGIBLE!</span>
+          <span className="text-heading3">YOU ARE ELIGIBLE!</span>
           <span className="text-body3 text-neutralGreen-700">
             TOKENS TO CLAIM
           </span>
@@ -100,6 +101,19 @@ export const ClaimContent = () => {
             </Button>
           }
         />
+        <div className='flex w-full items-center justify-center mt-5'>
+          <span className="text-body5 text-neutralGreen-900">
+            <Link
+              size="medium"
+              className="text-body5 lg:text-body5 cursor-pointer"
+              onClick={() => {
+                setCurrentContent('check-eligibility');
+              }}
+            >
+              Check another wallet
+            </Link>
+          </span>
+        </div>
       </div>
       <div className="mx-10 h-[434px] w-px bg-[radial-gradient(111.94%_122.93%_at_16.62%_0%,_#E7F5E7_0%,_#76C282_100%)] opacity-50" />
       <div className="flex w-[389px] flex-col">

--- a/apps/main-landing/src/app/claim/components/not-eligible/not-eligible-content.tsx
+++ b/apps/main-landing/src/app/claim/components/not-eligible/not-eligible-content.tsx
@@ -49,6 +49,7 @@ export const NotEligibleContent = () => {
               BUY ON JUMPER
             </Button>,
           ]}
+          additionalClasses="md:flex-col"
         />
         <div className="flex w-full items-center justify-center opacity-70">
           <span

--- a/apps/main-landing/src/components/token-section/components/geo-conditional-button.tsx
+++ b/apps/main-landing/src/components/token-section/components/geo-conditional-button.tsx
@@ -10,10 +10,12 @@ import { BlockedButton } from './blocked-button';
 
 type GeoConditionalButtonProperties = {
   defaultButton: React.ReactNode | React.ReactNode[]; // Support single or multiple buttons
+  additionalClasses?: string;
 };
 
 export const GeoConditionalButton: React.FC<GeoConditionalButtonProperties> = ({
   defaultButton,
+  additionalClasses = 'md:flex-row',
 }) => {
   const { country, loading } = useGeoLocation();
 
@@ -34,7 +36,9 @@ export const GeoConditionalButton: React.FC<GeoConditionalButtonProperties> = ({
 
   if (Array.isArray(defaultButton)) {
     return (
-      <div className="flex flex-col justify-center gap-6 md:flex-row">
+      <div
+        className={`flex flex-col justify-center gap-6 ${additionalClasses}`}
+      >
         {defaultButton}
       </div>
     );


### PR DESCRIPTION
## Overview
This PR addresses two issues present on design files on claim screen.
1. Buttons  "Buy on Uniswap" and "Buy on Jumper" were not spamming full different rows (they were in the same row).
2. There was no option to go back and check another wallet.