### PR TITLE
fix: updated after review

### DIFF
--- a/apps/main-landing/src/app/claim/claim-page-context.tsx
+++ b/apps/main-landing/src/app/claim/claim-page-context.tsx
@@ -14,10 +14,12 @@ type ClaimPageContextValues = {
   walletAddress: Hex | undefined;
   vestingPlan: VestingPlan | undefined;
   eligibilityData: EligibilityCheckResponse | undefined;
+  hasAlreadyClaimed: boolean;
   setCurrentContent: (currentContent: ClaimPageContent) => void;
   setWalletAddress: (walletAddress: Hex) => void;
   setVestingPlan: (vestingPlan: VestingPlan) => void;
   setEligibilityData: (eligibilityData: EligibilityCheckResponse) => void;
+  setHasAlreadyClaimed: (hasAlreadyClaimed: boolean) => void;
 };
 
 export type VestingPlan = 'claim_50' | 'claim_and_stake_100';
@@ -33,6 +35,7 @@ export const ClaimPageProvider = ({ children }: Properties) => {
   const [eligibilityData, setEligibilityData] =
     useState<EligibilityCheckResponse>();
   const [walletAddress, setWalletAddress] = useState<Hex>();
+  const [hasAlreadyClaimed, setHasAlreadyClaimed] = useState(false);
 
   return (
     <ClaimPageContext.Provider
@@ -41,10 +44,12 @@ export const ClaimPageProvider = ({ children }: Properties) => {
         walletAddress,
         currentContent,
         eligibilityData,
+        hasAlreadyClaimed,
         setVestingPlan,
         setWalletAddress,
         setCurrentContent,
         setEligibilityData,
+        setHasAlreadyClaimed,
       }}
     >
       {children}

--- a/apps/main-landing/src/app/claim/components/check-eligibility/check-eligibility-content.tsx
+++ b/apps/main-landing/src/app/claim/components/check-eligibility/check-eligibility-content.tsx
@@ -35,8 +35,12 @@ const baseClient = createPublicClient({
 });
 
 export const CheckEligibilityContent = () => {
-  const { setCurrentContent, setWalletAddress, setEligibilityData } =
-    useClaimPage();
+  const {
+    setCurrentContent,
+    setWalletAddress,
+    setEligibilityData,
+    setHasAlreadyClaimed,
+  } = useClaimPage();
   const { data: walletClient } = useWalletClient();
   const formMethods = useForm<FormPayload>({
     defaultValues: {
@@ -83,6 +87,7 @@ export const CheckEligibilityContent = () => {
 
     if (isClaimed) {
       setCurrentContent('claim-successful');
+      setHasAlreadyClaimed(true);
       return;
     }
     setCurrentContent(eligibility.allocation ? 'claim' : 'not-eligible');

--- a/apps/main-landing/src/app/claim/components/claim-successful/claim-successful-content.tsx
+++ b/apps/main-landing/src/app/claim/components/claim-successful/claim-successful-content.tsx
@@ -17,7 +17,8 @@ import idrissCoinsCircle from './assets/IDRISS_SCENE_CIRCLE_2 2.png';
 import { SOCIALS } from './constants';
 
 export const ClaimSuccessfulContent = () => {
-  const { setCurrentContent, eligibilityData, vestingPlan } = useClaimPage();
+  const { setCurrentContent, eligibilityData, vestingPlan, hasAlreadyClaimed } =
+    useClaimPage();
   const downloadAreaReference = useRef<HTMLDivElement>(null);
 
   if (!eligibilityData) {
@@ -32,63 +33,67 @@ export const ClaimSuccessfulContent = () => {
         gradientStopColor="rgba(145, 206, 154, 0.50)"
         borderWidth={1}
       />
-      <span className="text-heading4 text-neutral-900">CLAIM SUCCESSFUL</span>
-      <div
-        ref={downloadAreaReference}
-        className="relative flex h-[354px] w-[480px] flex-col items-center justify-center gap-6 self-stretch overflow-hidden rounded-2xl bg-mint-100 p-6"
-      >
-        <img
-          alt=""
-          src={idrissCoinsCircle.src}
-          className="pointer-events-none absolute left-0 top-0"
-        />
-        <IconButton
-          size="large"
-          iconName="Download"
-          intent="tertiary"
-          iconClassName="size-6"
-          onMouseDown={async () => {
-            if (!downloadAreaReference.current) {
-              return;
-            }
+      <span className="text-heading4 text-neutral-900">
+        {hasAlreadyClaimed ? 'TOKENS ALREADY CLAIMED' : 'CLAIM SUCCESSFUL'}
+      </span>
+      {!hasAlreadyClaimed && (
+        <div
+          ref={downloadAreaReference}
+          className="relative flex h-[354px] w-[480px] flex-col items-center justify-center gap-6 self-stretch overflow-hidden rounded-2xl bg-mint-100 p-6"
+        >
+          <img
+            alt=""
+            src={idrissCoinsCircle.src}
+            className="pointer-events-none absolute left-0 top-0"
+          />
+          <IconButton
+            size="large"
+            iconName="Download"
+            intent="tertiary"
+            iconClassName="size-6"
+            onMouseDown={async () => {
+              if (!downloadAreaReference.current) {
+                return;
+              }
 
-            const dataUrl = await toPng(downloadAreaReference.current, {
-              pixelRatio: 5,
-            });
-            const link = document.createElement('a');
-            link.href = dataUrl;
-            link.setAttribute('download', `claim-successful.png`);
-            document.body.append(link);
-            link.click();
-            link.remove();
-          }}
-          className="absolute right-6 top-6 flex size-6 p-0 text-mint-500 active:opacity-0"
-        />
-        <div className="relative flex w-full flex-row justify-center" />
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-body4 text-neutralGreen-700">
-            {vestingPlan === 'claim_50'
-              ? 'YOU RECEIVED'
-              : 'UNLOCK ON JULY 6, 2025'}
-          </span>
-          <div className="z-10 flex flex-col items-center justify-center rounded-[12px] border-[0.683px] border-[rgba(85,235,60,0.30)] bg-[radial-gradient(50%_50%_at_50%_50%,_rgba(252,255,242,0.00)_0%,_rgba(23,255,74,0.18)_100%)] px-10 py-5.5">
-            <span className="text-heading3 gradient-text">
-              +
-              {new Intl.NumberFormat('en-US', {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0,
-              }).format(
-                Number(
-                  vestingPlan === 'claim_50'
-                    ? (eligibilityData.allocation ?? 0) / 2
-                    : (eligibilityData.allocation ?? 0),
-                ),
-              )}{' '}
-              $IDRISS
+              const dataUrl = await toPng(downloadAreaReference.current, {
+                pixelRatio: 5,
+              });
+              const link = document.createElement('a');
+              link.href = dataUrl;
+              link.setAttribute('download', `claim-successful.png`);
+              document.body.append(link);
+              link.click();
+              link.remove();
+            }}
+            className="absolute right-6 top-6 flex size-6 p-0 text-mint-500 active:opacity-0"
+          />
+          <div className="relative flex w-full flex-row justify-center" />
+          <div className="flex flex-col items-center gap-2">
+            <span className="text-body4 text-neutralGreen-700">
+              {vestingPlan === 'claim_50'
+                ? 'YOU RECEIVED'
+                : 'UNLOCK ON JULY 6, 2025'}
             </span>
+            <div className="z-10 flex flex-col items-center justify-center rounded-[12px] border-[0.683px] border-[rgba(85,235,60,0.30)] bg-[radial-gradient(50%_50%_at_50%_50%,_rgba(252,255,242,0.00)_0%,_rgba(23,255,74,0.18)_100%)] px-10 py-5.5">
+              <span className="text-heading3 gradient-text">
+                +
+                {new Intl.NumberFormat('en-US', {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0,
+                }).format(
+                  Number(
+                    vestingPlan === 'claim_50'
+                      ? (eligibilityData.allocation ?? 0) / 2
+                      : (eligibilityData.allocation ?? 0),
+                  ),
+                )}{' '}
+                $IDRISS
+              </span>
+            </div>
           </div>
         </div>
-      </div>
+      )}
       {vestingPlan === 'claim_50' ? (
         <GeoConditionalButton
           defaultButton={
@@ -106,7 +111,7 @@ export const ClaimSuccessfulContent = () => {
       ) : (
         <div className="flex w-full flex-col gap-4">
           <GeoConditionalButton
-            defaultButton={
+            defaultButton={[
               <Button
                 key="uniswap"
                 intent="primary"
@@ -118,11 +123,7 @@ export const ClaimSuccessfulContent = () => {
                 className="w-full"
               >
                 BUY MORE ON UNISWAP
-              </Button>
-            }
-          />
-          <GeoConditionalButton
-            defaultButton={
+              </Button>,
               <Button
                 key="jumper"
                 intent="primary"
@@ -134,8 +135,9 @@ export const ClaimSuccessfulContent = () => {
                 className="w-full"
               >
                 BUY MORE ON JUMPER
-              </Button>
-            }
+              </Button>,
+            ]}
+            additionalClasses="md:flex-col"
           />
           <div className="flex w-full items-center justify-center opacity-70">
             <span

--- a/apps/main-landing/src/app/claim/components/letter/letter-content.tsx
+++ b/apps/main-landing/src/app/claim/components/letter/letter-content.tsx
@@ -12,6 +12,7 @@ import { useClaimPage } from '../../claim-page-context';
 import geoist_avatar from './assets/geoist_avatar.png';
 import levertz_avatar from './assets/levertz_avatar.png';
 import you_avatar from './assets/you_avatar.png';
+import { GeoConditionalButton } from '@/components/token-section/components/geo-conditional-button';
 
 export const LetterContent = () => {
   const { setCurrentContent } = useClaimPage();
@@ -90,17 +91,21 @@ export const LetterContent = () => {
           <span className="text-label5 text-neutral-900">You</span>
         </div>
       </div>
-      <Button
-        intent="primary"
-        size="large"
-        suffixIconName="ArrowRight"
-        className="w-56"
-        onClick={() => {
-          setCurrentContent('about-idriss');
-        }}
-      >
-        Next
-      </Button>
+      <GeoConditionalButton
+        defaultButton={
+          <Button
+            intent="primary"
+            size="large"
+            suffixIconName="ArrowRight"
+            className="w-56"
+            onClick={() => {
+              setCurrentContent('about-idriss');
+            }}
+          >
+            Next
+          </Button>
+        }
+      />
     </div>
   );
 };

--- a/apps/main-landing/src/app/claim/components/letter/letter-content.tsx
+++ b/apps/main-landing/src/app/claim/components/letter/letter-content.tsx
@@ -7,12 +7,13 @@ import {
   TOKENOMICS_DOCS_LINK,
 } from '@idriss-xyz/constants';
 
+import { GeoConditionalButton } from '@/components/token-section/components/geo-conditional-button';
+
 import { useClaimPage } from '../../claim-page-context';
 
 import geoist_avatar from './assets/geoist_avatar.png';
 import levertz_avatar from './assets/levertz_avatar.png';
 import you_avatar from './assets/you_avatar.png';
-import { GeoConditionalButton } from '@/components/token-section/components/geo-conditional-button';
 
 export const LetterContent = () => {
   const { setCurrentContent } = useClaimPage();

--- a/apps/main-landing/src/app/claim/components/not-eligible/not-eligible-content.tsx
+++ b/apps/main-landing/src/app/claim/components/not-eligible/not-eligible-content.tsx
@@ -49,7 +49,6 @@ export const NotEligibleContent = () => {
               BUY ON JUMPER
             </Button>,
           ]}
-          additionalClasses="md:flex-col"
         />
         <div className="flex w-full items-center justify-center opacity-70">
           <span


### PR DESCRIPTION
- bring back flex-row in not eligible page

- geo block the first button on the claim page

- check if has already claimed and display accordingly on the claim-successful page

- add hasAlreadyClaimed to context, save it and use it