### PR TITLE
feat: updated airdrop and vault docs links

### DIFF
--- a/packages/constants/src/links.ts
+++ b/packages/constants/src/links.ts
@@ -47,8 +47,8 @@ export const PRIVACY_POLICY_LINK =
   'https://docs.idriss.xyz/resources/privacy-policy';
 export const TERMS_OF_SERVICE_LINK =
   'https://docs.idriss.xyz/resources/terms-of-service';
-export const AIRDROP_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/airdrop';
-export const VAULT_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/vault';
+export const AIRDROP_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/retroactive-distribution';
+export const VAULT_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/retroactive-distribution#vault';
 export const TOKENOMICS_DOCS_LINK =
   'https://docs.idriss.xyz/idriss-token/tokenomics';
 


### PR DESCRIPTION
## Overview

- updated `AIRDROP_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/airdrop'` to `AIRDROP_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/retroactive-distribution'`

- updated `VAULT_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/vault'` to `VAULT_DOCS_LINK = 'https://docs.idriss.xyz/idriss-token/retroactive-distribution#vault'`