### PR TITLE
feat: Add fetch claim Events and store on file

### DIFF
--- a/apps/copilot-api/.gitignore
+++ b/apps/copilot-api/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules/
 dist/
+claimedEvents.json

--- a/apps/copilot-api/index.ts
+++ b/apps/copilot-api/index.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { mode } from './utils/mode';
 import { createConfig } from '@lifi/sdk';
 import { connectedClients } from './services/scheduler';
+import { startFetchingClaimEvents } from './utils/claimEvents';
 
 dotenv.config(
   mode === 'production' ? {} : { path: join(__dirname, `.env.${mode}`) },
@@ -91,6 +92,8 @@ createConfig({
   integrator: process.env.LIFI_INTEGRATOR_STRING ?? 'IDRISS',
   apiKey: process.env.LIFI_API_KEY,
 });
+
+startFetchingClaimEvents();
 
 server.listen(PORT, () => {
   console.log(`Server is running at port ${PORT}`);

--- a/apps/copilot-api/utils/claimEvents.ts
+++ b/apps/copilot-api/utils/claimEvents.ts
@@ -1,0 +1,57 @@
+import { createPublicClient, http, parseAbiItem } from 'viem';
+import { base } from 'viem/chains';
+import fs from 'fs';
+
+const CLAIMED_EVENT = 'event Claimed(address by, address token, address to, uint256 total, uint256[] claimIndices, bytes memo, bool bonus)';
+const CLAIM_CONTRACT_ADDRESS = '0xfD76c3a2A4534D815c9C5127119e6ea738A28837';
+
+let latestBlockRead = BigInt(25614734);
+
+export async function fetchAndWriteClaimEvents() {
+  try {
+
+    const client = createPublicClient({
+      chain: base,
+      transport: http('https://base-rpc.publicnode.com'),
+    });
+
+    const parsedEvent = parseAbiItem(CLAIMED_EVENT);
+
+    const claimLogs = await client.getLogs({
+      address: CLAIM_CONTRACT_ADDRESS,
+      event: parsedEvent,
+      fromBlock: latestBlockRead,
+      toBlock: 'latest'
+    });
+
+    const claimedEvents: Record<string, { bonus: boolean; total: string }> = {};
+
+    for (const log of claimLogs) {
+      const { args } = log;
+      if (!args) continue;
+
+      const { to, total, bonus } = args;
+
+      if (!to || !total || !bonus) continue;
+
+      claimedEvents[to] = {
+        bonus,
+        total: total.toString()
+      };
+    }
+
+    const existingEvents = fs.existsSync('claimedEvents.json')
+      ? JSON.parse(fs.readFileSync('claimedEvents.json', 'utf-8'))
+      : {};
+    const mergedEvents = { ...existingEvents, ...claimedEvents };
+    fs.writeFileSync('claimedEvents.json', JSON.stringify(mergedEvents, null, 2));
+    latestBlockRead = claimLogs[claimLogs.length - 1].blockNumber;
+  }
+  catch (error) {
+    console.error("Failed fetching claim events. ", error);
+  }
+}
+
+export function startFetchingClaimEvents() {
+  setInterval(fetchAndWriteClaimEvents, 5000);
+}


### PR DESCRIPTION
## Overview
Indexes event data on Claim contract for CLaimed events, and saves new records to a json file on the server called claimEvents. Event is:
`event Claimed(address by, address token, address to, uint256 total, uint256[] claimIndices, bytes memo, bool bonus)`
Data used for json file:
`const { to, total, bonus }`
Structure of json file:
`{address: {bonus: true/false, total: amount}}`

If server restart, it will read events from initial block `25614734`

## Pending
- [ ] Add endpoint to API to return claimed events for address only?
- [ ] Read from frontend and show total (parse units too)
- [ ] Merge copilot-dev to master?