### PR TITLE
fix: added missing space in token section on mobile

### DIFF
--- a/apps/main-landing/src/components/token-section/token-section.tsx
+++ b/apps/main-landing/src/components/token-section/token-section.tsx
@@ -76,7 +76,7 @@ export const TokenSection = () => {
               )}
             >
               IDRISS is the utility token powering{'\u00A0'}the IDRISS{'\u00A0'}
-              DAO, giving you access{'\u00A0'}to
+              DAO, giving you access{'\u00A0'}to{'\u00A0'}
               <br className="hidden lg:block" />
               decentralized{'\u00A0'}revenue sharing, governance rights, and
               more.


### PR DESCRIPTION
## Overview

- added missing space in token section on mobile

#### Proof

![image](https://github.com/user-attachments/assets/e7533fd0-e4a3-4827-a9a8-eed23744b407)
