### PR TITLE
fix: update spacing on vault page

### DIFF
--- a/apps/main-landing/src/app/vault/content.tsx
+++ b/apps/main-landing/src/app/vault/content.tsx
@@ -51,7 +51,7 @@ export const StakingContent = () => {
       />
 
       <div className="flex flex-col">
-        <div className="z-[5] mt-[40px] inline-flex flex-col items-center gap-[78px] overflow-hidden px-4 pb-3 lg:mt-[120px] lg:[@media(max-height:800px)]:mt-[60px]">
+        <div className="z-[5] mt-[40px] inline-flex flex-col items-center gap-[40px] overflow-hidden px-4 pb-3 lg:mt-[100px] lg:[@media(max-height:800px)]:mt-[60px]">
           <img
             className="hidden size-[137px] lg:block"
             src={idrissCoin.src}


### PR DESCRIPTION
## Overview

- made spacing smaller on vault page

#### Proof

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/4348c8dc-f621-4090-967d-22e16865478c" />
