### PR TITLE
fix: pass only number without commas in unstake handleSubmit

### DIFF
--- a/apps/main-landing/src/app/claim/components/vesting-plan/vesting-plan-content.tsx
+++ b/apps/main-landing/src/app/claim/components/vesting-plan/vesting-plan-content.tsx
@@ -275,15 +275,23 @@ export const VestingPlanContent = () => {
                 tokens
               </span>
             </div>
-            <div className="flex gap-2">
-              <Icon name="Gem" size={24} className="text-gray-300" />
+            <div className="flex gap-2.5">
+              <Icon
+                name="Gem"
+                size={24}
+                className="ml-[2px] size-[38px] text-gray-300"
+              />
               <span className="text-body3 text-neutralGreen-700">
                 Lock <span className="gradient-text">10,000 $IDRISS</span> or
                 more to access premium features
               </span>
             </div>
-            <div className="flex gap-2">
-              <Icon name="PieChart" size={24} className="text-gray-300" />
+            <div className="flex gap-2.5">
+              <Icon
+                name="PieChart"
+                size={24}
+                className="ml-[3px] size-[36px] text-gray-300"
+              />
               <span className="text-body3 text-neutralGreen-700">
                 Tap into decentralized revenue sharing from IDRISS apps
               </span>

--- a/apps/main-landing/src/app/vault/components/stake-tab-content.tsx
+++ b/apps/main-landing/src/app/vault/components/stake-tab-content.tsx
@@ -42,7 +42,7 @@ type FormPayload = {
 const txLoadingHeading = (amount: number) => {
   return (
     <>
-      Locking <span className="text-mint-600">{amount.toLocaleString()}</span>{' '}
+      Locking <span className="text-mint-600">{amount?.toLocaleString()}</span>{' '}
       IDRISS
     </>
   );
@@ -124,9 +124,6 @@ export const StakeTabContent = () => {
   });
 
   const { handleSubmit, control, watch } = useForm<FormPayload>({
-    defaultValues: {
-      amount: 1,
-    },
     mode: 'onSubmit',
   });
 
@@ -230,7 +227,7 @@ export const StakeTabContent = () => {
               <Form.Field
                 {...field}
                 className="mt-4 lg:mt-6"
-                value={field.value.toString()}
+                value={field.value?.toString()}
                 onChange={(value) => {
                   field.onChange(Number(value));
                 }}

--- a/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
+++ b/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
@@ -204,7 +204,7 @@ export const UnstakeTabContent = () => {
                 {totalLockedAmount} IDRISS
               </p>
             ) : (
-              <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
+              <p className="text-label3 text-neutralGreen-700">— IDRISS</p>
             )}
           </div>
           <div className="flex flex-row items-center justify-between">
@@ -214,7 +214,7 @@ export const UnstakeTabContent = () => {
                 {stakedAmount} IDRISS
               </p>
             ) : (
-              <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
+              <p className="text-label3 text-neutralGreen-700">— IDRISS</p>
             )}
           </div>
           <div className="flex flex-row items-center justify-between">
@@ -226,7 +226,7 @@ export const UnstakeTabContent = () => {
                 {blockedAmount} IDRISS
               </p>
             ) : (
-              <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
+              <p className="text-label3 text-neutralGreen-700">— IDRISS</p>
             )}
           </div>
         </div>

--- a/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
+++ b/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
@@ -245,7 +245,7 @@ export const UnstakeTabContent = () => {
                 className="mt-4 lg:mt-6"
                 value={field.value.toString()}
                 onChange={(value) => {
-                  field.onChange(Number(value));
+                  field.onChange(Number(value.replaceAll(',', '')));
                 }}
                 label={
                   <div className="flex justify-between">
@@ -256,7 +256,7 @@ export const UnstakeTabContent = () => {
                       <div
                         className="flex text-label6 text-neutral-800 hover:cursor-pointer"
                         onClick={() => {
-                          field.onChange(stakedAmount);
+                          field.onChange(stakedAmount?.replaceAll(',', ''));
                         }}
                       >
                         Available:{' '}

--- a/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
+++ b/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
@@ -37,8 +37,8 @@ type FormPayload = {
 const txLoadingHeading = (amount: number) => {
   return (
     <>
-      Unlocking <span className="text-mint-600">{amount.toLocaleString()}</span>{' '}
-      IDRISS
+      Unlocking{' '}
+      <span className="text-mint-600">{amount?.toLocaleString()}</span> IDRISS
     </>
   );
 };
@@ -60,9 +60,6 @@ export const UnstakeTabContent = () => {
     transport: http(),
   });
   const { handleSubmit, control, watch } = useForm<FormPayload>({
-    defaultValues: {
-      amount: 1,
-    },
     mode: 'onSubmit',
   });
 
@@ -243,7 +240,7 @@ export const UnstakeTabContent = () => {
               <Form.Field
                 {...field}
                 className="mt-4 lg:mt-6"
-                value={field.value.toString()}
+                value={field.value?.toString()}
                 onChange={(value) => {
                   field.onChange(Number(value.replaceAll(',', '')));
                 }}

--- a/apps/main-landing/src/app/vault/content.tsx
+++ b/apps/main-landing/src/app/vault/content.tsx
@@ -80,15 +80,23 @@ export const StakingContent = () => {
                     locked tokens
                   </span>
                 </div>
-                <div className="flex gap-1 lg:gap-2">
-                  <Icon name="Gem" size={24} className="text-gray-300" />
+                <div className="flex gap-1.5 lg:gap-2.5">
+                  <Icon
+                    name="Gem"
+                    size={24}
+                    className="ml-[3px] text-gray-300 lg:ml-[2px] lg:size-[38px]"
+                  />
                   <span className="text-body4 text-neutralGreen-700 lg:text-body3">
                     Lock <span className="gradient-text">10,000 $IDRISS</span>{' '}
                     or more to access premium features
                   </span>
                 </div>
-                <div className="flex gap-1 lg:gap-2">
-                  <Icon name="PieChart" size={24} className="text-gray-300" />
+                <div className="flex gap-1.5 lg:gap-2.5">
+                  <Icon
+                    name="PieChart"
+                    size={24}
+                    className="ml-[3px] text-gray-300 lg:size-[36px]"
+                  />
                   <span className="text-body4 text-neutralGreen-700 lg:text-body3">
                     Tap into decentralized revenue sharing from IDRISS apps
                   </span>


### PR DESCRIPTION
- pass only number without commas in unstake handleSubmit

- removed the default 1 in staking and unstaking inputs

- replaced dashes with em dashes

- aligned icons in vault benefits section

#### Proof

![image](https://github.com/user-attachments/assets/20e8a509-57b2-42a9-a444-423803e46487)

![image](https://github.com/user-attachments/assets/0f43948a-05ae-45a5-abc8-34e7b0c9aa75)

![image](https://github.com/user-attachments/assets/15a1adaa-2cac-4466-93d8-63bc093ed7b0)

![image](https://github.com/user-attachments/assets/fb2eba17-f69b-4570-a161-050e43f0c1dc)
