### PR TITLE
Fix/vault mobile issues

### DIFF
--- a/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
+++ b/apps/main-landing/src/app/vault/components/unstake-tab-content.tsx
@@ -197,44 +197,44 @@ export const UnstakeTabContent = () => {
   return (
     <>
       <TxLoadingModal show={isLoading} heading={txLoadingHeading(amount)} />
-      <div className="relative mt-4 lg:mt-6">
-        <RadialGradientBorder />
-        <div className="flex flex-col gap-y-2 rounded-2xl bg-white/20 p-6">
-          <div className="flex flex-row items-center justify-between">
-            <p className="text-body4 text-neutralGreen-500">Total locked</p>
-            {totalLockedAmount ? (
-              <p className="text-label3 text-neutralGreen-700">
-                {totalLockedAmount} IDRISS
+      <Form className="w-full" onSubmit={handleSubmit(handleUnstake)}>
+        <div className="relative mt-4 lg:mt-6">
+          <RadialGradientBorder />
+          <div className="flex flex-col gap-y-2 rounded-2xl bg-white/20 p-6">
+            <div className="flex flex-row items-center justify-between">
+              <p className="text-body4 text-neutralGreen-500">Total locked</p>
+              {totalLockedAmount ? (
+                <p className="text-label3 text-neutralGreen-700">
+                  {totalLockedAmount} IDRISS
+                </p>
+              ) : (
+                <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
+              )}
+            </div>
+            <div className="flex flex-row items-center justify-between">
+              <p className="text-body4 text-neutralGreen-500">Unlockable</p>
+              {stakedAmount ? (
+                <p className="text-label3 text-neutralGreen-700">
+                  {stakedAmount} IDRISS
+                </p>
+              ) : (
+                <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
+              )}
+            </div>
+            <div className="flex flex-row items-center justify-between">
+              <p className="text-body4 text-neutralGreen-500">
+                Unlockable from July 6
               </p>
-            ) : (
-              <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
-            )}
-          </div>
-          <div className="flex flex-row items-center justify-between">
-            <p className="text-body4 text-neutralGreen-500">Unlockable</p>
-            {stakedAmount ? (
-              <p className="text-label3 text-neutralGreen-700">
-                {stakedAmount} IDRISS
-              </p>
-            ) : (
-              <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
-            )}
-          </div>
-          <div className="flex flex-row items-center justify-between">
-            <p className="text-body4 text-neutralGreen-500">
-              Unlockable from July 6
-            </p>
-            {blockedAmount ? (
-              <p className="text-label3 text-neutralGreen-700">
-                {blockedAmount} IDRISS
-              </p>
-            ) : (
-              <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
-            )}
+              {blockedAmount ? (
+                <p className="text-label3 text-neutralGreen-700">
+                  {blockedAmount} IDRISS
+                </p>
+              ) : (
+                <p className="text-label3 text-neutralGreen-700">0 IDRISS</p>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-      <Form className="w-full" onSubmit={handleSubmit(handleUnstake)}>
         <Controller
           control={control}
           name="amount"

--- a/apps/main-landing/src/app/vault/content.tsx
+++ b/apps/main-landing/src/app/vault/content.tsx
@@ -38,7 +38,7 @@ export const StakingContent = () => {
   }, []);
 
   return (
-    <main className="relative flex min-h-screen grow flex-col items-center justify-around overflow-hidden bg-[radial-gradient(181.94%_192.93%_at_16.62%_0%,_#E7F5E7_0%,_#76C282_100%)] lg:flex-row lg:items-start lg:justify-center lg:px-0">
+    <main className="relative min-h-screen items-center justify-around overflow-hidden bg-[radial-gradient(181.94%_192.93%_at_16.62%_0%,_#E7F5E7_0%,_#76C282_100%)] lg:flex-row lg:items-start lg:justify-center lg:px-0">
       <img
         src={idrissSceneStream.src}
         className="pointer-events-none absolute left-[-310px] top-[-20px] z-1 h-[1440px] w-[2306.px] min-w-[120vw] max-w-none rotate-[25.903deg] lg:block"
@@ -50,7 +50,7 @@ export const StakingContent = () => {
         alt=""
       />
 
-      <div className="flex flex-col">
+      <div className="flex flex-col mt-16 lg:mt-0 ">
         <div className="z-[5] mt-[40px] inline-flex flex-col items-center gap-[78px] overflow-hidden px-4 pb-3 lg:mt-[120px] lg:[@media(max-height:800px)]:mt-[60px]">
           <img
             className="hidden size-[137px] lg:block"

--- a/apps/main-landing/src/app/vault/content.tsx
+++ b/apps/main-landing/src/app/vault/content.tsx
@@ -41,7 +41,7 @@ export const StakingContent = () => {
     <main className="relative min-h-screen items-center justify-around overflow-hidden bg-[radial-gradient(181.94%_192.93%_at_16.62%_0%,_#E7F5E7_0%,_#76C282_100%)] lg:flex-row lg:items-start lg:justify-center lg:px-0">
       <img
         src={idrissSceneStream.src}
-        className="pointer-events-none absolute left-[-310px] top-[-20px] z-1 h-[1440px] w-[2306.px] min-w-[120vw] max-w-none rotate-[25.903deg] lg:block"
+        className="pointer-events-none absolute left-[-550px] top-[120px] z-1 h-[1007.44px] w-[1614.91px] min-w-[120vw] max-w-none rotate-[48.76deg] lg:left-[-310px] lg:top-[-20px] lg:block lg:h-[1440px] lg:w-[2306.px] lg:rotate-[25.903deg]"
         alt=""
       />
       <img
@@ -50,7 +50,7 @@ export const StakingContent = () => {
         alt=""
       />
 
-      <div className="flex flex-col mt-16 lg:mt-0 ">
+      <div className="mt-16 flex flex-col lg:mt-0">
         <div className="z-[5] mt-[40px] inline-flex flex-col items-center gap-[78px] overflow-hidden px-4 pb-3 lg:mt-[120px] lg:[@media(max-height:800px)]:mt-[60px]">
           <img
             className="hidden size-[137px] lg:block"


### PR DESCRIPTION
## Overview
Fixes these issues:
1. Background is slightly different than on pc (lighter).
2. After switching to 'unlock' tab, the modal is shifting up (should be the same top margin as in the design).
3. On  mobile browser the modal opens with huge top margin. [ DISREGARDED ]
4. There is no Vault button in the hamburger menu. [ FIXED ON #373 ]

## How it was fixed
1. Changed postiioning, size and rotation of bg image on mobile screens (adding `lg:` modifiers to previous Tailwind classes).
![Captura desde 2025-01-29 18-31-02](https://github.com/user-attachments/assets/6eefe995-ad08-4eb4-a97b-a1e8f73fe636)

2.  Removed flex and grow classes on StakeContent main container and added top margin 16 for mobile screens.
[Video](https://github.com/user-attachments/assets/025baba0-2a78-4f2f-a42a-b978d9227a7d)