### PR TITLE
fix: replace icons with our custom idriss arrow

### DIFF
--- a/apps/main-landing/src/app/claim/components/about-idriss/about-idriss-content.tsx
+++ b/apps/main-landing/src/app/claim/components/about-idriss/about-idriss-content.tsx
@@ -172,7 +172,7 @@ export const AboutIdrissContent = () => {
               <Button
                 intent="primary"
                 size="large"
-                suffixIconName="ArrowRight"
+                suffixIconName="IdrissArrowRight"
                 className="w-56"
                 onClick={() => {
                   setCurrentContent('check-eligibility');

--- a/apps/main-landing/src/app/claim/components/check-eligibility/check-eligibility-content.tsx
+++ b/apps/main-landing/src/app/claim/components/check-eligibility/check-eligibility-content.tsx
@@ -185,7 +185,7 @@ export const CheckEligibilityContent = () => {
           <Button
             intent="primary"
             size="large"
-            suffixIconName="ArrowRight"
+            suffixIconName="IdrissArrowRight"
             onClick={verifyEligibility}
             loading={
               resolveEnsAddressMutation.isPending ||

--- a/apps/main-landing/src/app/claim/components/claim/claim-content.tsx
+++ b/apps/main-landing/src/app/claim/components/claim/claim-content.tsx
@@ -236,7 +236,7 @@ export const ClaimContent = () => {
           isExternal
           asLink
           className="mt-8 w-full"
-          suffixIconName="ArrowRight"
+          suffixIconName="IdrissArrowRight"
           href={AIRDROP_DOCS_LINK}
         >
           LEARN MORE

--- a/apps/main-landing/src/app/claim/components/letter/letter-content.tsx
+++ b/apps/main-landing/src/app/claim/components/letter/letter-content.tsx
@@ -97,7 +97,7 @@ export const LetterContent = () => {
           <Button
             intent="primary"
             size="large"
-            suffixIconName="ArrowRight"
+            suffixIconName="IdrissArrowRight"
             className="w-56"
             onClick={() => {
               setCurrentContent('about-idriss');

--- a/apps/main-landing/src/app/claim/components/vesting-plan/vesting-plan-content.tsx
+++ b/apps/main-landing/src/app/claim/components/vesting-plan/vesting-plan-content.tsx
@@ -304,7 +304,7 @@ export const VestingPlanContent = () => {
             isExternal
             asLink
             className="mt-8 w-full"
-            suffixIconName="ArrowRight"
+            suffixIconName="IdrissArrowRight"
             href={VAULT_DOCS_LINK}
           >
             LEARN MORE

--- a/apps/main-landing/src/app/vault/content.tsx
+++ b/apps/main-landing/src/app/vault/content.tsx
@@ -109,7 +109,7 @@ export const StakingContent = () => {
                 isExternal
                 asLink
                 className="mb-4 mt-6 w-full lg:mt-8"
-                suffixIconName="ArrowRight"
+                suffixIconName="IdrissArrowRight"
                 href={VAULT_DOCS_LINK}
               >
                 LEARN MORE


### PR DESCRIPTION
## Overview

- replaced all usages of `ArrowRight` from `lucide-dev` library with our custom icon named `IdrissArrowRight` on /claim and /vault pages

#### Proof

<img width="737" alt="image" src="https://github.com/user-attachments/assets/aee2d23a-b299-4ee5-b42a-2e8f61de9729" />
