### PR TITLE
fix: display amount of claimed tokens as one string

### DIFF
--- a/apps/main-landing/src/app/claim/components/claim-successful/claim-successful-content.tsx
+++ b/apps/main-landing/src/app/claim/components/claim-successful/claim-successful-content.tsx
@@ -78,18 +78,16 @@ export const ClaimSuccessfulContent = () => {
             </span>
             <div className="z-10 flex items-center justify-center gap-3 rounded-[12px] border-[0.683px] border-[rgba(85,235,60,0.30)] bg-[radial-gradient(50%_50%_at_50%_50%,_rgba(252,255,242,0.00)_0%,_rgba(23,255,74,0.18)_100%)] px-10 py-5.5">
               <span className="text-heading3 gradient-text">
-                +
-                {new Intl.NumberFormat('en-US', {
+                {`+${new Intl.NumberFormat('en-US', {
                   minimumFractionDigits: 0,
                   maximumFractionDigits: 0,
                 }).format(
                   Number(
                     vestingPlan === 'claim_50'
-                      ? (eligibilityData.allocation ?? 0) / 2
-                      : (eligibilityData.allocation ?? 0),
+                      ? (eligibilityData?.allocation ?? 0) / 2
+                      : (eligibilityData?.allocation ?? 0),
                   ),
-                )}{' '}
-                $IDRISS
+                )} $IDRISS`}
               </span>
               <div className="relative">
                 <Icon name="IdrissCircled" size={40} />


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/8243b3f5-50bb-4e9c-9f17-059251d8ae7a)

After:
![image](https://github.com/user-attachments/assets/ca4ad9f2-3d0e-4d90-ab4b-4fa5813a9168)

This is a potential fix. However, due to the lack of specific information about the browser type and version, it has not been fully tested. I believe older versions of certain browsers may have issues rendering it correctly. For example, in my version of Firefox, the code appeared as follows:
![image](https://github.com/user-attachments/assets/d2e84849-0925-4cdf-a18c-963e6fff3263)
