### PR TITLE
fix: set correct input width in copilot dialog

### DIFF
--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -322,7 +322,7 @@ const TradingCopilotDialogContent = ({
                   placeholder="ETH"
                   onChange={onChange}
                   decimalScale={5}
-                  className="ps-[60px] text-right"
+                  className="w-[358px] ps-[60px] text-right"
                 />
                 <div className="pointer-events-none absolute start-0 top-1/2 flex h-full w-12 -translate-y-1/2 items-center justify-center after:absolute after:right-0 after:top-1.5 after:h-[calc(100%_-_12px)] after:w-px after:bg-neutral-200">
                   <span className="flex size-6 items-center justify-center rounded-full bg-neutral-200">


### PR DESCRIPTION
## Overview

- input for the amount in copilot dialog was displayed as not full width, this will set the correct width for it according to mockups in figma

#### Proof

<img width="507" alt="image" src="https://github.com/user-attachments/assets/2057f579-c054-4ee3-8590-11a3e9fadc78" />