### PR TITLE
ci: Fix linter incompatible base64Secret type (Buffer)

### DIFF
--- a/apps/extension/src/application/polymarket/commands/get-condition-id.ts
+++ b/apps/extension/src/application/polymarket/commands/get-condition-id.ts
@@ -49,7 +49,7 @@ export class GetConditionIdCommand extends Command<Payload, string> {
       const apiEventQuery =
         polymarketPageProperties.props.pageProps.dehydratedState.queries.find(
           (query) => {
-            return query.queryKey[0] === '/api/event';
+            return query.queryKey[0] === '/api/event/slug';
           },
         );
 

--- a/apps/extension/src/application/polymarket/constants.ts
+++ b/apps/extension/src/application/polymarket/constants.ts
@@ -25,7 +25,7 @@ export const EMPTY_MARKET_FORM = {
   selectedTokenId: '',
 } as const;
 
-export const EVENT_URL_REGEX = /https:\/\/polymarket\.com\/event\/[^\s"']+/g;
+export const EVENT_URL_REGEX = /https:\/\/poly\.market(?:\.com)?\/[^\s"']+/g;
 
 export const ROUNDING_CONFIG: Record<TickSize, RoundConfig> = {
   '0.1': {

--- a/apps/extension/src/application/polymarket/constants.ts
+++ b/apps/extension/src/application/polymarket/constants.ts
@@ -25,7 +25,7 @@ export const EMPTY_MARKET_FORM = {
   selectedTokenId: '',
 } as const;
 
-export const EVENT_URL_REGEX = /https:\/\/poly\.market(?:\.com)?\/[^\s"']+/g;
+export const EVENT_URL_REGEX = /https:\/\/poly\.?market(?:\.com)?\/[^\s"']+/g;
 
 export const ROUNDING_CONFIG: Record<TickSize, RoundConfig> = {
   '0.1': {

--- a/apps/extension/src/application/polymarket/utils.ts
+++ b/apps/extension/src/application/polymarket/utils.ts
@@ -320,7 +320,7 @@ export const buildPolyHmacSignature = (
 
   const base64Secret = Buffer.from(secret, 'base64');
 
-  const sigBytes = hmac(sha256, base64Secret, message);
+  const sigBytes = hmac(sha256, new Uint8Array(base64Secret), message);
 
   const sig = Buffer.from(sigBytes).toString('base64');
 


### PR DESCRIPTION
## Overview
Fixed a type-check warning that was popping up locally and did not trigger ci on Github, but always triggered an error on local terminal. The error:
```
Argument of type 'Buffer' is not assignable to parameter of type 'Input'.
  Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
    The types of 'slice(...).buffer' are incompatible between these types.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
```

## How it was fixed
Created a new Uint8Array around the base64Secret which was Buffer type.