### PR TITLE
Feat/copilot error handling

### DIFF
--- a/apps/copilot-api/middleware/error.middleware.ts
+++ b/apps/copilot-api/middleware/error.middleware.ts
@@ -1,3 +1,4 @@
+import { AxiosResponse } from 'axios';
 import { Response } from 'express';
 
 export const throwInternalError = (
@@ -6,5 +7,13 @@ export const throwInternalError = (
   error: unknown,
 ) => {
   console.error(`${msg}: `, error);
-  res.status(500).json({ error: 'Internal server error' });
+  res.status(500).json({ error: 'Internal server error', message: msg });
+};
+
+
+export const throwExternalError = (
+  res: AxiosResponse,
+  msg: string,
+)  => {
+  throw new Error(`[${res.status}] ${msg}: ${res.statusText}`);
 };

--- a/apps/copilot-api/middleware/error.middleware.ts
+++ b/apps/copilot-api/middleware/error.middleware.ts
@@ -10,10 +10,6 @@ export const throwInternalError = (
   res.status(500).json({ error: 'Internal server error', message: msg });
 };
 
-
-export const throwExternalError = (
-  res: AxiosResponse,
-  msg: string,
-)  => {
+export const throwExternalError = (res: AxiosResponse, msg: string) => {
   throw new Error(`[${res.status}] ${msg}: ${res.statusText}`);
 };

--- a/apps/copilot-api/routes/auth.ts
+++ b/apps/copilot-api/routes/auth.ts
@@ -52,9 +52,6 @@ router.post('/wallet-address', async (req, res) => {
   }
 });
 
-// TODO: On empty list of subscriptions on extension, callying this will
-// return 401, since the subscriber is removed from the database on /unsubscribe
-// last address.
 router.post('/verify-token', async (req, res) => {
   const { token } = req.body;
 

--- a/apps/copilot-api/services/auth.ts
+++ b/apps/copilot-api/services/auth.ts
@@ -61,7 +61,7 @@ export function createMessage(
     chainId,
     domain,
     nonce,
-    uri: `https://${domain}`, // TODO: Change for production
+    uri: `https://${domain}`,
     version: '1',
     issuedAt: timestamp,
     expirationTime: new Date(

--- a/apps/copilot-api/services/subscriptionManager.ts
+++ b/apps/copilot-api/services/subscriptionManager.ts
@@ -71,18 +71,6 @@ export const unsubscribeAddress = async (
   try {
     await subscriptionsRepo.delete({ subscriber_id: subscriberId, address });
 
-    // Check if the subscriber has any other subscriptions
-    const subscriberRes = await subscriptionsRepo.count({
-      where: { subscriber_id: subscriberId },
-    });
-
-    // TODO: Check remove. This causes extension to prompt for SIWE on emptying subscription
-    // list and trying to subscribe again.
-    if (parseInt(subscriberRes.toString(), 10) === 0) {
-      // Subscriber has no more subscriptions, remove from subscribers table
-      await subscribersRepo.delete({ subscriber_id: subscriberId });
-    }
-
     // Check if the address has any other subscribers
     const addressRes = await subscriptionsRepo.count({ where: { address } });
 

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscription-form.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscription-form.tsx
@@ -104,7 +104,7 @@ export const SubscriptionForm = ({ onSubmit, canSubscribe }: Properties) => {
         await onSubmit({ address: ensAddress, chainType: 'EVM' });
         form.reset(EMPTY_FORM);
         setError('');
-      } catch (error) {
+      } catch {
         setError('We couldn\'t subscribe to this address. Try again.');
       }
     },

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscription-form.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscription-form.tsx
@@ -105,7 +105,7 @@ export const SubscriptionForm = ({ onSubmit, canSubscribe }: Properties) => {
         form.reset(EMPTY_FORM);
         setError('');
       } catch {
-        setError('We couldn\'t subscribe to this address. Try again.');
+        setError("We couldn't subscribe to this address. Try again.");
       }
     },
     [

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/components/subscription-item/subscription-item.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/components/subscription-item/subscription-item.tsx
@@ -123,15 +123,16 @@ const SubscriptionItemContent = ({
   });
 
   useEffect(() => {
-      if (showError) {
-        const timer = setTimeout(() => {
-          setShowError(false);
-        }, 2000);
-        return () => {return clearTimeout(timer)};
-      }
-      return undefined;
-    }, [showError]);
-
+    if (showError) {
+      const timer = setTimeout(() => {
+        setShowError(false);
+      }, 3000);
+      return () => {
+        return clearTimeout(timer);
+      };
+    }
+    return undefined;
+  }, [showError]);
 
   const shortenedName =
     isAddress(name) || isSolanaAddress(name) ? getShortWalletHex(name) : name;
@@ -166,6 +167,7 @@ const SubscriptionItemContent = ({
               {shortenedName}
             </TradingCopilotTooltip>
           )}
+          {showError && <span className="ml-2 text-red-500">Try again.</span>}
           {twitterQuery.data && (
             <ExternalLink href={getTwitterUserLink(twitterQuery.data)}>
               <IdrissIcon
@@ -204,22 +206,14 @@ const SubscriptionItemContent = ({
           )}
         </p>
       </div>
-      {showError ? (
-        <IconButton
-          size="small"
-          iconName="AlertCircle"
-          intent="tertiary"
-          className="text-neutral-400"
-        />
-      ) : (
-        <IconButton
-          size="small"
-          iconName="X"
-          intent="tertiary"
-          className="text-red-500"
-          onClick={removeSubscription}
-        />
-      )}
+      <IconButton
+        size="small"
+        iconName="X"
+        intent="tertiary"
+        className="text-red-500"
+        onClick={removeSubscription}
+        disabled={showError}
+      />
     </li>
   );
 };

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/components/subscription-item/subscription-item.tsx
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/components/subscription-item/subscription-item.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ExternalLink } from '@idriss-xyz/ui/external-link';
 import { Icon as IdrissIcon } from '@idriss-xyz/ui/icon';
 import { IconButton } from '@idriss-xyz/ui/icon-button';
@@ -72,13 +72,18 @@ const SubscriptionItemContent = ({
 }: ContentProperties) => {
   const ensNameNotFound = isAddress(name);
   const isFarcasterSubscription = !!farcasterDetails;
+  const [showError, setShowError] = useState(false);
 
-  const removeSubscription = useCallback(() => {
-    onRemove({
-      address: subscription.address,
-      fid: subscription.fid,
-      chainType: isSolanaAddress(subscription.address) ? 'SOLANA' : 'EVM',
-    });
+  const removeSubscription = useCallback(async () => {
+    try {
+      await onRemove({
+        address: subscription.address,
+        fid: subscription.fid,
+        chainType: isSolanaAddress(subscription.address) ? 'SOLANA' : 'EVM',
+      });
+    } catch {
+      setShowError(true);
+    }
   }, [onRemove, subscription]);
 
   const emailQuery = useCommandQuery({
@@ -116,6 +121,17 @@ const SubscriptionItemContent = ({
     staleTime: Number.POSITIVE_INFINITY,
     enabled: !ensNameNotFound,
   });
+
+  useEffect(() => {
+      if (showError) {
+        const timer = setTimeout(() => {
+          setShowError(false);
+        }, 2000);
+        return () => {return clearTimeout(timer)};
+      }
+      return undefined;
+    }, [showError]);
+
 
   const shortenedName =
     isAddress(name) || isSolanaAddress(name) ? getShortWalletHex(name) : name;
@@ -188,13 +204,22 @@ const SubscriptionItemContent = ({
           )}
         </p>
       </div>
-      <IconButton
-        size="small"
-        iconName="X"
-        intent="tertiary"
-        className="text-red-500"
-        onClick={removeSubscription}
-      />
+      {showError ? (
+        <IconButton
+          size="small"
+          iconName="AlertCircle"
+          intent="tertiary"
+          className="text-neutral-400"
+        />
+      ) : (
+        <IconButton
+          size="small"
+          iconName="X"
+          intent="tertiary"
+          className="text-red-500"
+          onClick={removeSubscription}
+        />
+      )}
     </li>
   );
 };

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/components/subscription-item/subscription-item.types.ts
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/components/subscription-item/subscription-item.types.ts
@@ -6,7 +6,7 @@ import {
 
 export interface Properties {
   subscription: SubscriptionResponse;
-  onRemove: (payload: UnsubscribePayload) => void;
+  onRemove: (payload: UnsubscribePayload) => Promise<void>;
 }
 
 export interface ContentProperties extends Properties {

--- a/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/subscription-list.types.ts
+++ b/apps/extension/src/application/trading-copilot/subscriptions-management/components/subscriptions-list/subscription-list.types.ts
@@ -8,5 +8,5 @@ export interface Properties {
   subscriptionsAmount?: number;
   subscriptionsLoading: boolean;
   subscriptions?: SubscriptionsResponse;
-  onRemove: (payload: UnsubscribePayload) => void;
+  onRemove: (payload: UnsubscribePayload) => Promise<void>;
 }

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.tsx
@@ -32,8 +32,6 @@ import {
 import { useCommandQuery } from 'shared/messaging';
 import {
   FormValues,
-  GetEnsInfoCommand,
-  GetEnsNameCommand,
   GetQuoteCommand,
   useExchanger,
   useSolanaExchanger,
@@ -47,7 +45,6 @@ import { TokenIcon } from '../../utils';
 
 import {
   Properties,
-  ContentProperties,
   WalletBalanceProperties,
   TradeValueProperties,
 } from './trading-copilot-dialog.types';
@@ -84,18 +81,9 @@ export const TradingCopilotDialog = ({
   closeDialog,
   tokenData,
   tokenImage,
+  userName,
+  userAvatar,
 }: Properties) => {
-  const ensNameQuery = useCommandQuery({
-    command: new GetEnsNameCommand({
-      address: dialog.from,
-    }),
-    staleTime: Number.POSITIVE_INFINITY,
-  });
-
-  if (ensNameQuery.isFetching) {
-    return;
-  }
-
   return (
     <Closable
       className="fixed left-0 top-0 z-portal size-full bg-black/50"
@@ -106,9 +94,10 @@ export const TradingCopilotDialog = ({
           <TradingCopilotDialogContent
             tokenData={tokenData}
             tokenImage={tokenImage}
+            userName={userName}
+            userAvatar={userAvatar}
             dialog={dialog}
             closeDialog={closeDialog}
-            userName={ensNameQuery.data ?? dialog.from}
           />
           <div className="self-stretch text-center opacity-70">
             <span
@@ -142,10 +131,11 @@ export const TradingCopilotDialog = ({
 const TradingCopilotDialogContent = ({
   dialog,
   userName,
+  userAvatar,
   closeDialog,
   tokenData,
   tokenImage,
-}: ContentProperties) => {
+}: Properties) => {
   const {
     wallet: ensWallet,
     isConnectionModalOpened,
@@ -163,14 +153,6 @@ const TradingCopilotDialogContent = ({
   const exchanger = isSolanaTrade ? solanaExchanger : evmExchanger;
   const wallet = isSolanaTrade ? solanaWallet : ensWallet;
   const siwe = useLoginViaSiwe();
-
-  const avatarQuery = useCommandQuery({
-    command: new GetEnsInfoCommand({
-      ensName: userName,
-      infoKey: 'avatar',
-    }),
-    staleTime: Number.POSITIVE_INFINITY,
-  });
 
   const balance = useAccountBalance(wallet);
 
@@ -287,7 +269,7 @@ const TradingCopilotDialogContent = ({
       </div>
       <div className="grid grid-cols-[48px,1fr] gap-2 py-2">
         <LazyImage
-          src={avatarQuery.data}
+          src={userAvatar}
           className="size-12 rounded-full border border-neutral-400 bg-neutral-200"
           fallbackComponent={
             <div className="flex size-12 items-center justify-center rounded-full border border-neutral-300 bg-neutral-200">

--- a/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.types.ts
+++ b/apps/extension/src/final/notifications-popup/components/trading-copilot-dialog/trading-copilot-dialog.types.ts
@@ -8,10 +8,8 @@ export interface Properties {
   closeDialog: () => void;
   tokenData: SwapDataToken | null;
   tokenImage: string;
-}
-
-export interface ContentProperties extends Properties {
   userName: string;
+  userAvatar: string | null;
 }
 
 export interface WalletBalanceProperties {

--- a/apps/extension/src/final/notifications-popup/notifications-popup.tsx
+++ b/apps/extension/src/final/notifications-popup/notifications-popup.tsx
@@ -63,6 +63,8 @@ const NotificationsPopupContent = ({
   const farcasterUserMutation = useCommandMutation(GetFarcasterUserCommand);
   const tokenListMutation = useCommandMutation(GetTokensListCommand);
   const tokenIconMutation = useCommandMutation(GetTokensImageCommand);
+  const [name, setName] = useState<string | null>(null);
+  const [avatar, setAvatar] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isSwapEventListenerAdded.current) {
@@ -108,9 +110,15 @@ const NotificationsPopupContent = ({
 
         if (userDetails) {
           ensName = userDetails.name;
-          avatarImage = await imageMutation.mutateAsync({
-            src: userDetails.avatar ?? '',
-          });
+          avatarImage =
+            (await imageMutation.mutateAsync({
+              src: userDetails.avatar ?? '',
+            })) ?? '';
+          setName(userDetails.name);
+          setAvatar(avatarImage);
+        } else {
+          setName(null);
+          setAvatar(null);
         }
 
         const tokensList = await tokenListMutation.mutateAsync();
@@ -185,6 +193,8 @@ const NotificationsPopupContent = ({
     <TradingCopilotDialog
       tokenData={selectedToken.current}
       tokenImage={selectedTokenImage.current}
+      userName={name ?? activeDialog.from}
+      userAvatar={avatar}
       dialog={activeDialog}
       closeDialog={closeDialog}
     />

--- a/apps/extension/src/final/notifications-popup/notifications-popup.tsx
+++ b/apps/extension/src/final/notifications-popup/notifications-popup.tsx
@@ -16,7 +16,7 @@ import {
   SwapData,
   SwapDataToken,
 } from 'application/trading-copilot';
-import { GetImageCommand } from 'shared/utils';
+import { GetImageCommand, isCorrectImageString } from 'shared/utils';
 import { CHAIN, SubscriptionsStorage } from 'shared/web3';
 
 import { TradingCopilotToast, TradingCopilotDialog } from './components';
@@ -114,6 +114,9 @@ const NotificationsPopupContent = ({
             (await imageMutation.mutateAsync({
               src: userDetails.avatar ?? '',
             })) ?? '';
+          if (!isCorrectImageString(avatarImage)) {
+            avatarImage = null;
+          }
           setName(userDetails.name);
           setAvatar(avatarImage);
         } else {

--- a/apps/extension/src/final/notifications-popup/utils/token-icon.tsx
+++ b/apps/extension/src/final/notifications-popup/utils/token-icon.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@idriss-xyz/ui/icon';
 import { useEffect, useState } from 'react';
 
 import { SwapDataToken } from 'application/trading-copilot';
+import { isCorrectImageString } from 'shared/utils';
 
 interface TokenIconProperties {
   tokenData: SwapDataToken | null;
@@ -14,9 +15,6 @@ export const TokenIcon: React.FC<TokenIconProperties> = ({
 }) => {
   const [icon, setIcon] = useState<JSX.Element | null>(null);
 
-  const tokenImageArray = tokenImage.split('/');
-  const isCorrectImage = tokenImageArray[0] === 'data:image';
-
   useEffect(() => {
     const loadIcon = () => {
       if (tokenImage === 'IdrissToken') {
@@ -24,7 +22,7 @@ export const TokenIcon: React.FC<TokenIconProperties> = ({
           <Icon name="IdrissToken" size={24} className="size-6 rounded-full" />,
         );
       } else {
-        if (tokenData && isCorrectImage) {
+        if (tokenData && isCorrectImageString(tokenImage)) {
           setIcon(
             <img
               src={tokenImage}

--- a/apps/extension/src/infrastructure/service-worker/service-worker.ts
+++ b/apps/extension/src/infrastructure/service-worker/service-worker.ts
@@ -92,19 +92,9 @@ export class ServiceWorker {
         'color: #FF9900;',
       );
       const wallet = await ExtensionSettingsManager.getWallet();
-      const subscriptionsAmount =
-        await TradingCopilotManager.getSubscriptionsAmount();
 
       if (wallet?.account) {
-        if (subscriptionsAmount) {
-          this.registerWithServer(wallet.account);
-        } else {
-          console.log(
-            '%c[WebSocket] User dont have any subscriptions.',
-            'color: red;',
-          );
-          this.socket.disconnect();
-        }
+        this.registerWithServer(wallet.account);
       } else {
         console.log('%c[WebSocket] User not found.', 'color: red;');
         this.socket.disconnect();

--- a/apps/extension/src/shared/utils/index.ts
+++ b/apps/extension/src/shared/utils/index.ts
@@ -7,3 +7,7 @@ export {
 export { getDifferenceInDays, getEndsInLabel } from './date-utils';
 export { isFarcasterName } from './subscription-utils';
 export { reverseObject, createLookup } from './objects';
+
+export const isCorrectImageString = (image: string) => {
+  return image.startsWith('data:image');
+};


### PR DESCRIPTION
## Overview
Adds error handling to copilot api and extension on frontend. Also groups db and webhook transactions into one unit transaction (commits changes only if everything went through, rollback if anything failed). All features included:
- Throw specific error messages on external calls (calls to Helius or Alchemy api for example). 
- Wrap subscribe endpoint transactions in EntittyTransaction from typeorm.
- Wrap unsubscribe endpoint transactions in EntittyTransaction from typeorm.
- Add feedback on extension for unsuccesful subscribe. Shows "We couldn't subscribe to this address. Try again." in red below input, dissapears after 5 seconds.
![image](https://github.com/user-attachments/assets/3794901e-36fe-49a3-ade3-556ac6f877ce)

- Add feedback on extension for unsuccesful unsubscribe . Shows "Try again" in red next to the address in subscription list, blocks remove X button. Goes back to normal after 3 seconds.
![image](https://github.com/user-attachments/assets/d4cd8fe8-57fe-47ad-9fb4-5472de46a3b0)
