### PR TITLE
fix: coinmarketcap icon size

### DIFF
--- a/packages/ui/src/components/icon/custom/coinmarketcap.tsx
+++ b/packages/ui/src/components/icon/custom/coinmarketcap.tsx
@@ -42,6 +42,7 @@ export const CoinmarketcapOutlined = ({ size, className }: Properties) => {
       width={size}
       height={size}
       fill="none"
+      viewBox="0 0 18.5 18.5"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/26126624-20d7-44b3-ba12-4a498a717175)
