### PR TITLE
fix: Margin on 4xl screens (change maxWidth)

### DIFF
--- a/packages/tailwind-config/tailwind.config.mjs
+++ b/packages/tailwind-config/tailwind.config.mjs
@@ -451,7 +451,7 @@ export default {
             maxWidth: '1312px',
           },
           '@screen 4xl': {
-            maxWidth: '1696px',
+            maxWidth: '1600px',
           },
         },
       });


### PR DESCRIPTION
## Overview
Fixes an issue with margin for containers on 4xl screens (from 1696px width).

## How it was solved
Changed maxWidth attribute for 4xl screens on tailwind config 