### PR TITLE
fix: Play alert sound if sfx fails

### DIFF
--- a/apps/main-landing/src/app/creators/obs/hooks/use-donation-notification.ts
+++ b/apps/main-landing/src/app/creators/obs/hooks/use-donation-notification.ts
@@ -119,7 +119,9 @@ export const useDonationNotification = (
           return requestAnimationFrame(resolve);
         });
 
-        const playAndWait = async (audioElement: HTMLAudioElement | null): Promise<boolean> => {
+        const playAndWait = async (
+          audioElement: HTMLAudioElement | null,
+        ): Promise<boolean> => {
           if (!audioElement) return false;
           return new Promise<boolean>((resolvePromise) => {
             const onEnded = () => {


### PR DESCRIPTION
## Overview
Fixes an issue where if the sfx audio failed to play then the alert sound did not play either.

## How it was fixed
Added a way to return a boolean on play audio: true if it succedds and false if not, and if false then go ahead and play the alert sound.
TTs plays regardless of sfx failing. Alert should never fail since sound is a local file 