### PR TITLE
fix: Use creator og image on all sub routes of /creators

### DIFF
--- a/apps/main-landing/src/app/creators/layout.tsx
+++ b/apps/main-landing/src/app/creators/layout.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from 'next';
+import { metadata as landingMetadata } from '@/app/layout';
+
+export const metadata: Metadata = {
+  ...landingMetadata,
+  description:
+    'Creator monetization app that helps you earn more with instant payouts and near-zero platform cuts.',
+  openGraph: {
+    title: 'Make more, grow faster, take control',
+    description:
+      'Creator monetization app that helps you earn more with instant payouts and near-zero platform cuts.',
+    images: [
+      {
+        url: '/og-creators.png',
+      },
+    ],
+  },
+};
+
+export default function CreatorsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/main-landing/src/app/creators/layout.tsx
+++ b/apps/main-landing/src/app/creators/layout.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
+
 import { metadata as landingMetadata } from '@/app/layout';
 
+// ts-unused-exports:disable-next-line
 export const metadata: Metadata = {
   ...landingMetadata,
   description:
@@ -17,6 +19,7 @@ export const metadata: Metadata = {
   },
 };
 
+// ts-unused-exports:disable-next-line
 export default function CreatorsLayout({
   children,
 }: {

--- a/apps/main-landing/src/app/creators/page.tsx
+++ b/apps/main-landing/src/app/creators/page.tsx
@@ -1,26 +1,6 @@
 import { ScrollArea } from '@idriss-xyz/ui/scroll-area';
-import { Metadata } from 'next';
-
-import { metadata as landingMetadata } from '@/app/layout';
 
 import Content from './content';
-
-// ts-unused-exports:disable-next-line
-export const metadata: Metadata = {
-  ...landingMetadata,
-  description:
-    'Creator monetization app that helps you earn more with instant payouts and near-zero platform cuts.',
-  openGraph: {
-    title: 'Make more, grow faster, take control',
-    description:
-      'Creator monetization app that helps you earn more with instant payouts and near-zero platform cuts.',
-    images: [
-      {
-        url: '/og-creators.png',
-      },
-    ],
-  },
-};
 
 // ts-unused-exports:disable-next-line
 export default function Landing() {


### PR DESCRIPTION
## Overview
Creators og image was displaying only when navigating to /creators, but regular og image was displaying on sub routes (like /creators/app or /creators/[name]).

## How it was fixed
Added a layout file for the creators folder, that inherits main landing page metadata and overwrites some properties including og image. Sub routes then inherit these metadata properties and show the correct og-image