### PR TITLE
fix: Empty networks and tokens don't show default list on creator-profile form

### DIFF
--- a/apps/main-landing/src/app/creators/app/form.tsx
+++ b/apps/main-landing/src/app/creators/app/form.tsx
@@ -282,10 +282,17 @@ export function CreatorProfileForm() {
       );
       formMethods.setValue('minimumTTSAmount', creatorProfile.minimumTTSAmount);
       formMethods.setValue('minimumSfxAmount', creatorProfile.minimumSfxAmount);
-      formMethods.setValue('tokensSymbols', creatorProfile.tokens);
+      formMethods.setValue(
+        'tokensSymbols',
+        creatorProfile.tokens.length > 0
+          ? creatorProfile.tokens
+          : UNIQUE_ALL_TOKEN_SYMBOLS,
+      );
       formMethods.setValue(
         'chainsIds',
-        getChainIdsFromShortNames(creatorProfile.networks),
+        creatorProfile.networks.length > 0
+          ? getChainIdsFromShortNames(creatorProfile.networks)
+          : ALL_CHAIN_IDS,
       );
       formMethods.setValue('alertMuted', creatorProfile.alertMuted);
       formMethods.setValue('ttsMuted', creatorProfile.ttsMuted);


### PR DESCRIPTION
## Overview
Solves #560

## How it was solved
On reading creator profile info from db and setting the values on the form, added a check that if the arrays for tokens or chains are empty then use all tokens or all chains constants. Now it correctly shows as all selected on creators/app and creators/[name]