### PR TITLE
fix: Remove whitespace between tooltip box and arrow

### DIFF
--- a/packages/ui/src/components/tooltip/tooltip.css
+++ b/packages/ui/src/components/tooltip/tooltip.css
@@ -1,0 +1,3 @@
+[data-side="top"] span > svg {
+  transform: translateY(calc(100% - 7px));
+}

--- a/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import "./tooltip.css";
 
 import { classes } from '../../utils';
 


### PR DESCRIPTION
## Overview
Fixes an issue with the tooltip that when position was top (above the hovered item) then zooming in and out made a white space appear between the arrow and the text box, visible only on dark backgrounds like ours.

## How it was fixed
A css file with a class override was adde to the Radix tooltip component. The selector gets the arrow and translates the arrow a pixel up it's original traslation, making it overlap with the box and making the whitespace dissapear.
The value for `transform: translateY(calc(100% - 7px));` "7px" was a trial and error find, and it makes it so the traslation is not as harsh and not noticeable to the user. Assitant originally suggested "1px" as value but that did not change anything visually so 7px was found to be the ideal value.