### PR TITLE
fix: Redirect back to creators if not authenticated (QA 82)

### DIFF
--- a/apps/main-landing/src/app/creators/app/earnings/layout.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/layout.tsx
@@ -3,6 +3,8 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { TabsPill, TabItem } from '@idriss-xyz/ui/tabs-pill';
 
+import useRedirectIfNotAuthenticated from '../../hooks/use-redirect-not-authenticated';
+
 // ts-unused-exports:disable-next-line
 export default function EarningsLayout({
   children,
@@ -10,6 +12,7 @@ export default function EarningsLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  useRedirectIfNotAuthenticated();
 
   const earningsTabs: TabItem[] = [
     {

--- a/apps/main-landing/src/app/creators/app/layout.tsx
+++ b/apps/main-landing/src/app/creators/app/layout.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { BreadcrumbNavigation } from '@idriss-xyz/ui/breadcrumb';
 import { ScrollArea } from '@idriss-xyz/ui/scroll-area';
-import { useEffect } from 'react';
-import { usePrivy } from '@privy-io/react-auth';
 
 import { siteMap } from '../constants';
-import { useAuth } from '../context/auth-context';
+import useRedirectIfNotAuthenticated from '../hooks/use-redirect-not-authenticated';
 
 import { CreatorSocketManager } from './creator-socket-manager';
 import { Sidebar } from './sidebar';
@@ -15,19 +13,7 @@ import { TopBar } from './topbar';
 
 function Layout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const router = useRouter();
-  const { creatorLoading, creator } = useAuth();
-  const { ready, authenticated } = usePrivy();
-
-  useEffect(() => {
-    if (!ready || creatorLoading) {
-      return;
-    }
-    if (!authenticated || !creator) {
-      console.log('returning');
-      router.replace('/creators?login=true');
-    }
-  }, [ready, authenticated, creatorLoading, router, creator]);
+  useRedirectIfNotAuthenticated();
 
   return (
     <>

--- a/apps/main-landing/src/app/creators/app/profile/page.tsx
+++ b/apps/main-landing/src/app/creators/app/profile/page.tsx
@@ -19,6 +19,8 @@ import {
 } from '@/app/creators/components/layout';
 import { ConfirmationModal } from '@/app/creators/components/confirmation-modal';
 
+import useRedirectIfNotAuthenticated from '../../hooks/use-redirect-not-authenticated';
+
 const handleDeleteAccount = () => {
   // TODO: Implement backend call to save email
   console.log('Deleteing Account');
@@ -26,6 +28,7 @@ const handleDeleteAccount = () => {
 
 // ts-unused-exports:disable-next-line
 export default function ProfilePage() {
+  useRedirectIfNotAuthenticated();
   const [isExportWalletModalOpen, setIsExportWalletModalOpen] = useState(false);
   const [isDeleteAccountModalOpen, setIsDeleteAccountModalOpen] =
     useState(false);

--- a/apps/main-landing/src/app/creators/app/ranking/layout.tsx
+++ b/apps/main-landing/src/app/creators/app/ranking/layout.tsx
@@ -3,6 +3,8 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { TabsPill, TabItem } from '@idriss-xyz/ui/tabs-pill';
 
+import useRedirectIfNotAuthenticated from '../../hooks/use-redirect-not-authenticated';
+
 // ts-unused-exports:disable-next-line
 export default function RankingLayout({
   children,
@@ -10,6 +12,7 @@ export default function RankingLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  useRedirectIfNotAuthenticated();
 
   const rankingTabs: TabItem[] = [
     {

--- a/apps/main-landing/src/app/creators/app/setup/layout.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/layout.tsx
@@ -5,8 +5,9 @@ import { TabsPill, TabItem } from '@idriss-xyz/ui/tabs-pill';
 import { CREATORS_LINK } from '@idriss-xyz/constants';
 import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
 
-import { useAuth } from '../../context/auth-context';
 import { CopyInput } from '../../components/copy-input/copy-input';
+import useRedirectIfNotAuthenticated from '../../hooks/use-redirect-not-authenticated';
+import { useAuth } from '../../context/auth-context';
 
 // ts-unused-exports:disable-next-line
 export default function SetupLayout({
@@ -16,7 +17,7 @@ export default function SetupLayout({
 }) {
   const pathname = usePathname();
   const { creator } = useAuth();
-
+  useRedirectIfNotAuthenticated();
   const setupTabs: TabItem[] = [
     {
       name: 'Payment methods',

--- a/apps/main-landing/src/app/creators/hooks/use-redirect-not-authenticated.ts
+++ b/apps/main-landing/src/app/creators/hooks/use-redirect-not-authenticated.ts
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { usePrivy } from '@privy-io/react-auth';
+
+import { useAuth } from '../context/auth-context';
+
+const useRedirectIfNotAuthenticated = () => {
+  const router = useRouter();
+  const { creatorLoading, creator } = useAuth();
+  const { ready, authenticated } = usePrivy();
+
+  useEffect(() => {
+    if (!ready || creatorLoading) {
+      return;
+    }
+    if (!authenticated || !creator) {
+      router.replace('/creators?login=true');
+    }
+  }, [ready, authenticated, creatorLoading, router, creator]);
+};
+
+export default useRedirectIfNotAuthenticated;


### PR DESCRIPTION
## Overview

Fixes a potential workaround the users had to enter and navigate the creators v2 app without being authenticated.

## How it was solved

- Extracted the logic present in creators/app/layout (to redirect the users if privy session not present) to a new hook called use-redirect-not-authenticated
- Call this new hook in all other inner layouts (earnings, setup, profile and ranking) so in case the user is able to click and navigate to them they are still redirected back to creators/login screen

