### PR TITLE
fix: Hide toggles on payment-methods tab of setup dashboard (QA 89)

### DIFF
--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -84,7 +84,7 @@ const iconsForCardPaymentMethod: IconName[] = [
 
 const IconsRow = ({ icons }: { icons: IconName[] }) => {
   return (
-    <div className="-mt-4 flex flex-row items-center gap-2 px-12">
+    <div className="-mt-4 flex flex-row items-center gap-2">
       {icons.map((iconName, index) => {
         return (
           <div className="relative size-6" key={index}>
@@ -294,6 +294,7 @@ export default function PaymentMethods() {
                 });
               }}
               className="max-w-screen-xs"
+              switchClassname="hidden"
             />
             {/* Uncomment when we have second payment method ready */}
             {/* <IconsRow tokens={iconsForCryptoPaymentMethod} /> */}
@@ -370,6 +371,7 @@ export default function PaymentMethods() {
                 console.log('Not implemented yet');
               }}
               className="max-w-screen-xs"
+              switchClassname="hidden"
             />
             <IconsRow icons={iconsForCardPaymentMethod} />
           </FormFieldWrapper>

--- a/packages/ui/src/components/switch/switch.tsx
+++ b/packages/ui/src/components/switch/switch.tsx
@@ -1,18 +1,24 @@
 import * as RadixSwitch from '@radix-ui/react-switch';
 import { forwardRef } from 'react';
 
+import { classes } from '../../utils';
+
 type Properties = {
   value: boolean;
   onChange: (value: boolean) => void;
+  className?: string;
   disabled?: boolean;
 };
 
 export const Switch = forwardRef<HTMLButtonElement, Properties>(
-  ({ value, onChange, disabled }, reference) => {
+  ({ value, onChange, className, disabled }, reference) => {
     return (
       <RadixSwitch.Root
         ref={reference}
-        className="group p-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+        className={classes(
+          'group p-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
         checked={value}
         onCheckedChange={onChange}
         disabled={disabled}

--- a/packages/ui/src/components/toggle/toggle.tsx
+++ b/packages/ui/src/components/toggle/toggle.tsx
@@ -9,6 +9,7 @@ interface ToggleProperties {
   sublabel?: string;
   disabled?: boolean;
   className?: string;
+  switchClassname?: string;
   comingSoon?: boolean;
   onChange: (value: boolean) => void;
 }
@@ -21,6 +22,7 @@ export const Toggle = forwardRef<HTMLDivElement, ToggleProperties>(
       sublabel,
       disabled,
       className,
+      switchClassname,
       onChange,
       comingSoon = false,
       ...properties
@@ -33,7 +35,12 @@ export const Toggle = forwardRef<HTMLDivElement, ToggleProperties>(
         ref={reference}
         {...properties}
       >
-        <Switch value={value} onChange={onChange} disabled={disabled} />
+        <Switch
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          className={switchClassname}
+        />
         <div className="flex flex-col gap-0">
           {label && (
             <div className="flex items-center">


### PR DESCRIPTION
## Overview
Solves QA 89. If we want them back just remove the switchClassname hidden property. Also iconsrow position should have some padding to appear on the side.

Original:
<img width="849" height="880" alt="image" src="https://github.com/user-attachments/assets/04a6d0fc-470c-4e75-9f8e-a7bce2676f36" />

After solving:
<img width="511" height="605" alt="image" src="https://github.com/user-attachments/assets/fea0a02d-da14-453f-a2ce-af338bb026de" />
