### PR TITLE
fix: TTS label dissapears from donate form on legacy links

### DIFF
--- a/apps/main-landing/src/app/creators/donate/components/donate-form/donate-form.tsx
+++ b/apps/main-landing/src/app/creators/donate/components/donate-form/donate-form.tsx
@@ -471,7 +471,7 @@ export const DonateForm = forwardRef<HTMLDivElement, Properties>(
                             </Badge>
                           )}
                           {creatorInfo.minimumTTSAmount > 0 &&
-                            creatorInfo.ttsEnabled && (
+                            (isLegacyLink || creatorInfo.ttsEnabled) && (
                               <Badge type="info" variant="subtle">
                                 TTS ${creatorInfo.minimumTTSAmount}+
                               </Badge>


### PR DESCRIPTION
<img width="1215" height="859" alt="image" src="https://github.com/user-attachments/assets/c5d6904a-093d-4782-856d-128ff9bded93" />
