### PR TITLE
fix: Add correct icons on Transactions card (IDRISS coin with badges)

### DIFF
--- a/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
@@ -149,7 +149,7 @@ export default function EarningsStats() {
                 <span className="pointer-events-none absolute left-2 top-12 flex items-center justify-center rounded-full bg-mint-200 px-2 py-1.5 font-medium text-black">
                   <Icon
                     size={24}
-                    name="BadgeDollarSign"
+                    name="HandCoins"
                     className="mr-1 rounded-full bg-mint-600 p-1 text-white"
                   />
                   {stats.totalDonationsCount} donation
@@ -158,7 +158,7 @@ export default function EarningsStats() {
                 <span className="pointer-events-none absolute right-2 top-8 flex items-center justify-center rounded-full bg-mint-200 px-2 py-1.5 font-medium text-mint-900">
                   <Icon
                     size={24}
-                    name="Trophy"
+                    name="Users"
                     className="mr-1 rounded-full bg-mint-600 p-1 text-white"
                   />
                   {stats.distinctDonorsCount} donors


### PR DESCRIPTION
<img width="623" height="568" alt="image" src="https://github.com/user-attachments/assets/45b06f8f-f87d-416d-9049-33134eee8662" />

To be confirmed on main site (not sure if Group/Users icon in number of donors is the correct one)