### PR TITLE
fix: Change from custom Users icon to Lucide (Users2)

### DIFF
--- a/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
@@ -158,7 +158,7 @@ export default function EarningsStats() {
                 <span className="pointer-events-none absolute right-2 top-8 flex items-center justify-center rounded-full bg-mint-200 px-2 py-1.5 font-medium text-mint-900">
                   <Icon
                     size={24}
-                    name="Users"
+                    name="Users2"
                     className="mr-1 rounded-full bg-mint-600 p-1 text-white"
                   />
                   {stats.distinctDonorsCount} donors

--- a/packages/ui/src/components/icon/constants.ts
+++ b/packages/ui/src/components/icon/constants.ts
@@ -51,6 +51,7 @@ import {
   FileUp,
   Gamepad2,
   Paintbrush,
+  Users as Users2,
 } from 'lucide-react';
 
 import * as customIcons from './custom';
@@ -108,5 +109,6 @@ export const ICON = {
   FileUp,
   Gamepad2,
   Paintbrush,
+  Users2,
   ...customIcons,
 };


### PR DESCRIPTION
<img width="958" height="683" alt="image" src="https://github.com/user-attachments/assets/940667df-9d4b-443a-959e-ee32fadce803" />
