### PR TITLE
feat: Add early returns (to skeletons) before data loading (QA 100)

### DIFF
--- a/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
@@ -66,6 +66,10 @@ export default function EarningsBalance() {
 
   const hasBalance = !isLoading && !isError && tableData.length > 0;
 
+  if (!ready || !authenticated || isLoading) {
+    return null;
+  }
+
   const handleCopyLink = () => {
     if (creator?.donationUrl) {
       void copy(creator.donationUrl);

--- a/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
@@ -15,6 +15,7 @@ import { WithdrawWidget } from '@/app/creators/components/withdraw-widget';
 
 import { useAuth } from '../../../context/auth-context';
 import { useGetBalances } from '../commands/get-balances';
+import SkeletonEarnings from '../loading';
 
 import { BalanceTable } from './balance-table';
 
@@ -67,7 +68,7 @@ export default function EarningsBalance() {
   const hasBalance = !isLoading && !isError && tableData.length > 0;
 
   if (!ready || !authenticated || isLoading) {
-    return null;
+    return <SkeletonEarnings />;
   }
 
   const handleCopyLink = () => {

--- a/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
@@ -27,6 +27,7 @@ import { useGetTipHistory } from '@/app/creators/app/commands/get-donate-history
 import { DonateHistoryItem } from '@/app/creators/donate/components/donate-history/donate-history-item';
 
 import { useAuth } from '../../../context/auth-context';
+import SkeletonEarnings from '../loading';
 
 import { TokenLogo } from './token-logo';
 import { useGetRecipientStats } from './commands/get-recipient-stats';
@@ -143,7 +144,7 @@ export default function EarningsStats() {
     tipHistoryQuery.isLoading ||
     recipientStatsQuery.isLoading
   ) {
-    return null;
+    return <SkeletonEarnings />;
   }
 
   const handleCopyLink = () => {

--- a/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
@@ -137,6 +137,15 @@ export default function EarningsStats() {
     };
   }, [stats]);
 
+  if (
+    !ready ||
+    !authenticated ||
+    tipHistoryQuery.isLoading ||
+    recipientStatsQuery.isLoading
+  ) {
+    return null;
+  }
+
   const handleCopyLink = () => {
     if (creator?.donationUrl) {
       void copy(creator.donationUrl);

--- a/apps/main-landing/src/app/creators/app/earnings/top-donors/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/top-donors/page.tsx
@@ -13,6 +13,7 @@ import { IDRISS_SCENE_STREAM_LIGHT } from '@/assets';
 import { Leaderboard } from '@/app/creators/components/leaderboard';
 
 import { periodMap } from '../../ranking/commands/use-get-leaderboard';
+import SkeletonEarnings from '../loading';
 
 // ts-unused-exports:disable-next-line
 export default function TopDonors() {
@@ -59,7 +60,7 @@ export default function TopDonors() {
   }, [allDonations, activeFilter]);
 
   if (tipHistoryQuery.isLoading || !ready || !authenticated) {
-    return null;
+    return <SkeletonEarnings />;
   }
 
   return (

--- a/apps/main-landing/src/app/creators/app/earnings/top-donors/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/top-donors/page.tsx
@@ -58,6 +58,10 @@ export default function TopDonors() {
     });
   }, [allDonations, activeFilter]);
 
+  if (tipHistoryQuery.isLoading || !ready || !authenticated) {
+    return null;
+  }
+
   return (
     <div>
       <Leaderboard

--- a/apps/main-landing/src/app/creators/app/ranking/top-creators/page.tsx
+++ b/apps/main-landing/src/app/creators/app/ranking/top-creators/page.tsx
@@ -32,6 +32,10 @@ export default function TopCreators() {
     [leaderboardQuery.data],
   );
 
+  if (leaderboardQuery.isLoading) {
+    return null;
+  }
+
   return (
     <div>
       <Leaderboard

--- a/apps/main-landing/src/app/creators/app/ranking/top-creators/page.tsx
+++ b/apps/main-landing/src/app/creators/app/ranking/top-creators/page.tsx
@@ -6,6 +6,7 @@ import { Hex } from 'viem';
 import { Leaderboard } from '@/app/creators/components/leaderboard';
 
 import { useGetLeaderboard, periodMap } from '../commands/use-get-leaderboard';
+import SkeletonRanking from '../loading';
 
 // ts-unused-exports:disable-next-line
 export default function TopCreators() {
@@ -33,7 +34,7 @@ export default function TopCreators() {
   );
 
   if (leaderboardQuery.isLoading) {
-    return null;
+    return <SkeletonRanking />;
   }
 
   return (

--- a/apps/main-landing/src/app/creators/app/ranking/top-donors/page.tsx
+++ b/apps/main-landing/src/app/creators/app/ranking/top-donors/page.tsx
@@ -6,6 +6,7 @@ import { Hex } from 'viem';
 import { Leaderboard } from '@/app/creators/components/leaderboard';
 
 import { useGetLeaderboard, periodMap } from '../commands/use-get-leaderboard';
+import SkeletonRanking from '../loading';
 
 // ts-unused-exports:disable-next-line
 export default function TopDonors() {
@@ -19,7 +20,7 @@ export default function TopDonors() {
   });
 
   if (leaderboardQuery.isLoading || !ready || !authenticated) {
-    return null;
+    return <SkeletonRanking />;
   }
 
   return (

--- a/apps/main-landing/src/app/creators/app/ranking/top-donors/page.tsx
+++ b/apps/main-landing/src/app/creators/app/ranking/top-donors/page.tsx
@@ -10,13 +10,17 @@ import { useGetLeaderboard, periodMap } from '../commands/use-get-leaderboard';
 // ts-unused-exports:disable-next-line
 export default function TopDonors() {
   const [activeFilter, setActiveFilter] = useState('All time');
-  const { user } = usePrivy();
+  const { user, ready, authenticated } = usePrivy();
   const address = user?.wallet?.address as Hex | undefined;
 
   const leaderboardQuery = useGetLeaderboard({
     type: 'donor',
     period: periodMap[activeFilter]!,
   });
+
+  if (leaderboardQuery.isLoading || !ready || !authenticated) {
+    return null;
+  }
 
   return (
     <div>

--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -99,6 +99,7 @@ const IconsRow = ({ icons }: { icons: IconName[] }) => {
 // ts-unused-exports:disable-next-line
 export default function PaymentMethods() {
   const { creator } = useAuth();
+
   const [saveSuccess, setSaveSuccess] = useState<boolean | null>(null);
   const [toggleCrypto, setToggleCrypto] = useState(true);
 
@@ -274,6 +275,10 @@ export default function PaymentMethods() {
       });
     }
   }, [creator, formMethods]);
+
+  if (!creator) {
+    return null;
+  }
 
   return (
     <Card className="size-full">

--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -28,6 +28,8 @@ import {
   SectionHeader,
 } from '@/app/creators/components/layout';
 
+import SkeletonSetup from '../loading';
+
 type FormPayload = {
   name: string;
   address: string;
@@ -98,7 +100,7 @@ const IconsRow = ({ icons }: { icons: IconName[] }) => {
 
 // ts-unused-exports:disable-next-line
 export default function PaymentMethods() {
-  const { creator } = useAuth();
+  const { creator, creatorLoading } = useAuth();
 
   const [saveSuccess, setSaveSuccess] = useState<boolean | null>(null);
   const [toggleCrypto, setToggleCrypto] = useState(true);
@@ -276,8 +278,8 @@ export default function PaymentMethods() {
     }
   }, [creator, formMethods]);
 
-  if (!creator) {
-    return null;
+  if (creatorLoading) {
+    return <SkeletonSetup />;
   }
 
   return (

--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -314,6 +314,10 @@ export default function StreamAlerts() {
     return nonToggleDirtyFields.length > 0;
   }, [formMethods.formState]);
 
+  if (!creator) {
+    return null;
+  }
+
   return (
     <Card className="w-full">
       <div className="flex flex-col gap-6">

--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -30,6 +30,7 @@ import {
 
 import { File } from '../file-upload/file';
 import { Select } from '../select';
+import SkeletonSetup from '../loading';
 
 const UpgradeBox: React.FC = () => {
   return (
@@ -83,7 +84,7 @@ type FormPayload = {
 
 // ts-unused-exports:disable-next-line
 export default function StreamAlerts() {
-  const { creator } = useAuth();
+  const { creator, creatorLoading } = useAuth();
 
   const [saveSuccess, setSaveSuccess] = useState<boolean | null>(null);
   const [testDonationSuccess, setTestDonationSuccess] = useState<
@@ -314,8 +315,8 @@ export default function StreamAlerts() {
     return nonToggleDirtyFields.length > 0;
   }, [formMethods.formState]);
 
-  if (!creator) {
-    return null;
+  if (creatorLoading) {
+    return <SkeletonSetup />;
   }
 
   return (


### PR DESCRIPTION
## Overview
Solves QA 100:
fix skeletons / page loading sequence
example: I'm a returning user and I open Balance, I currently see skeletons --> empty state with "no donations yet" --> actual view with data. It should be skeletons --> actual view with data)
this applies to other pages with defined empty states as well (Stats and history, Top donors), i should not see the empty state as a transitional step, this is the job of skeletons