### PR TITLE
fix: Remove some fiat icons. Truncate text (QA 101)

### DIFF
--- a/apps/main-landing/src/app/creators/app/layout.tsx
+++ b/apps/main-landing/src/app/creators/app/layout.tsx
@@ -25,11 +25,11 @@ function Layout({ children }: { children: React.ReactNode }) {
         <div className="flex w-full flex-col">
           <TopBar />
           {/* Page Content */}
-          <main className="flex flex-1 flex-col overflow-hidden pb-3">
+          <main className="flex flex-1 flex-col overflow-hidden">
             <div className="px-3 py-2">
               <BreadcrumbNavigation pathname={pathname} siteMap={siteMap} />
             </div>
-            <ScrollArea className="flex-1 px-3">{children}</ScrollArea>
+            <ScrollArea className="flex-1 px-3 pb-3">{children}</ScrollArea>
           </main>
         </div>
       </div>

--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -75,10 +75,8 @@ const TOKENS_ORDER: Record<TokenSymbol, number> = {
 // ];
 
 const iconsForCardPaymentMethod: IconName[] = [
-  'AmericanExpress',
-  'Maestro',
   'Mastercard',
-  'Paypal',
+  'AmericanExpress',
   'Visa',
 ];
 
@@ -293,7 +291,7 @@ export default function PaymentMethods() {
                   return !previous;
                 });
               }}
-              className="max-w-screen-xs"
+              className="max-w-[336px]"
               switchClassname="hidden"
             />
             {/* Uncomment when we have second payment method ready */}
@@ -370,7 +368,7 @@ export default function PaymentMethods() {
               onChange={() => {
                 console.log('Not implemented yet');
               }}
-              className="max-w-screen-xs"
+              className="max-w-[336px]"
               switchClassname="hidden"
             />
             <IconsRow icons={iconsForCardPaymentMethod} />


### PR DESCRIPTION
## Overview
Fixes QA 101
payment methods fixes
- [x] 1. fix widow words (expand text field or add line breaks)
- [x] 2. shadow shouldnt have a clean cut
- [x] 3. [design revision] delete PayPal and Maestro logos
<img width="1087" height="566" alt="image" src="https://github.com/user-attachments/assets/c67e66fd-7791-4ce5-be27-d00cb0e8396a" />