### PR TITLE
fix: Persist "Unable to save changes" toast (QA 38)

### DIFF
--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -724,7 +724,6 @@ Do not share it with anyone or show it on stream."
           type="error"
           description="Don't forget to save when you are done"
           iconName="RefreshCw"
-          autoClose
         />
       )}
     </Card>


### PR DESCRIPTION
## Overview
Fixes one last bit of QA 38:
`needed: unsaved changes toast should persist` 