### PR TITLE
Fix: Toast (QA 110)

### DIFF
--- a/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
@@ -7,7 +7,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import { Hex } from 'viem';
 import { formatFiatValue } from '@idriss-xyz/utils';
 import { useState } from 'react';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '@/app/creators/hooks/use-copy-to-clipboard';
 import { IDRISS_SCENE_STREAM_4 } from '@/assets';
@@ -155,7 +155,7 @@ export default function EarningsBalance() {
       />
       {copied && (
         <div className="fixed bottom-[3vh] left-1/2 z-50 -translate-x-1/2">
-          <Alert
+          <Toast
             type="success"
             heading="Your link has been copied!"
             autoClose

--- a/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/balance/page.tsx
@@ -7,13 +7,13 @@ import { usePrivy } from '@privy-io/react-auth';
 import { Hex } from 'viem';
 import { formatFiatValue } from '@idriss-xyz/utils';
 import { useState } from 'react';
-import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '@/app/creators/hooks/use-copy-to-clipboard';
 import { IDRISS_SCENE_STREAM_4 } from '@/assets';
 import { WithdrawWidget } from '@/app/creators/components/withdraw-widget';
 
 import { useAuth } from '../../../context/auth-context';
+import { useToast } from '../../../context/toast-context';
 import { useGetBalances } from '../commands/get-balances';
 import SkeletonRanking from '../loading';
 
@@ -24,6 +24,7 @@ export default function EarningsBalance() {
   const { user, ready, authenticated } = usePrivy();
   const { copied, copy } = useCopyToClipboard();
   const { creator } = useAuth();
+  const { toast } = useToast();
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
   const [selectedToken, setSelectedToken] = useState<string>();
   const address = user?.wallet?.address as Hex | undefined;
@@ -74,6 +75,11 @@ export default function EarningsBalance() {
   const handleCopyLink = () => {
     if (creator?.donationUrl) {
       void copy(creator.donationUrl);
+      toast({
+        type: 'success',
+        heading: 'Your link has been copied!',
+        autoClose: true,
+      });
     }
   };
 
@@ -153,15 +159,6 @@ export default function EarningsBalance() {
           return setIsWithdrawModalOpen(false);
         }}
       />
-      {copied && (
-        <div className="fixed bottom-[3vh] left-1/2 z-50 -translate-x-1/2">
-          <Toast
-            type="success"
-            heading="Your link has been copied!"
-            autoClose
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
@@ -19,7 +19,6 @@ import { useMemo } from 'react';
 import { formatFiatValue } from '@idriss-xyz/utils';
 import { usePrivy } from '@privy-io/react-auth';
 import { Hex } from 'viem';
-import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '@/app/creators/hooks/use-copy-to-clipboard';
 import { backgroundLines2, IDRISS_COIN, IDRISS_SCENE_STREAM_4 } from '@/assets';
@@ -27,6 +26,7 @@ import { useGetTipHistory } from '@/app/creators/app/commands/get-donate-history
 import { DonateHistoryItem } from '@/app/creators/donate/components/donate-history/donate-history-item';
 
 import { useAuth } from '../../../context/auth-context';
+import { useToast } from '../../../context/toast-context';
 import SkeletonEarnings from '../loading';
 
 import { TokenLogo } from './token-logo';
@@ -44,6 +44,7 @@ export default function EarningsStats() {
   const { user, ready, authenticated } = usePrivy();
   const { copied, copy } = useCopyToClipboard();
   const { creator } = useAuth();
+  const { toast } = useToast();
   const address = user?.wallet?.address as Hex | undefined;
   const tipHistoryQuery = useGetTipHistory(
     {
@@ -150,6 +151,11 @@ export default function EarningsStats() {
   const handleCopyLink = () => {
     if (creator?.donationUrl) {
       void copy(creator.donationUrl);
+      toast({
+        type: 'success',
+        heading: 'Your link has been copied!',
+        autoClose: true,
+      });
     }
   };
 
@@ -405,15 +411,6 @@ export default function EarningsStats() {
             </div>
           </Card>
         </>
-      )}
-      {copied && (
-        <div className="fixed bottom-[3vh] left-1/2 z-50 -translate-x-1/2">
-          <Toast
-            type="success"
-            heading="Your link has been copied!"
-            autoClose
-          />
-        </div>
       )}
     </div>
   );

--- a/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
+++ b/apps/main-landing/src/app/creators/app/earnings/stats-and-history/page.tsx
@@ -19,7 +19,7 @@ import { useMemo } from 'react';
 import { formatFiatValue } from '@idriss-xyz/utils';
 import { usePrivy } from '@privy-io/react-auth';
 import { Hex } from 'viem';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '@/app/creators/hooks/use-copy-to-clipboard';
 import { backgroundLines2, IDRISS_COIN, IDRISS_SCENE_STREAM_4 } from '@/assets';
@@ -408,7 +408,7 @@ export default function EarningsStats() {
       )}
       {copied && (
         <div className="fixed bottom-[3vh] left-1/2 z-50 -translate-x-1/2">
-          <Alert
+          <Toast
             type="success"
             heading="Your link has been copied!"
             autoClose

--- a/apps/main-landing/src/app/creators/app/profile/page.tsx
+++ b/apps/main-landing/src/app/creators/app/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { Button } from '@idriss-xyz/ui/button';
 import { Card } from '@idriss-xyz/ui/card';
 import { getAccessToken, usePrivy } from '@privy-io/react-auth';
@@ -10,7 +10,6 @@ import { Icon } from '@idriss-xyz/ui/icon';
 import Image from 'next/image';
 import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
 import { Checkbox } from '@idriss-xyz/ui/checkbox';
-import { Toast } from '@idriss-xyz/ui/toast';
 
 import { IDRISS_SCENE_STREAM_4, backgroundLines2 } from '@/assets';
 import { useAuth } from '@/app/creators/context/auth-context';
@@ -20,6 +19,7 @@ import {
   SectionHeader,
 } from '@/app/creators/components/layout';
 import { ConfirmationModal } from '@/app/creators/components/confirmation-modal';
+import { useToast } from '@/app/creators/context/toast-context';
 
 import { editCreatorProfile } from '../../utils';
 
@@ -34,27 +34,33 @@ export default function ProfilePage() {
   const [isDeleteAccountModalOpen, setIsDeleteAccountModalOpen] =
     useState(false);
   const [receiveEmails, setReceiveEmails] = useState(true);
-  const [saveSuccess, setSaveSuccess] = useState<boolean | null>(null);
 
   const { creator } = useAuth();
   const { user, exportWallet } = usePrivy();
+  const { toast } = useToast();
   const address = user?.wallet?.address as Hex | undefined;
-
-  const handleAlertClose = useCallback(() => {
-    setSaveSuccess(null);
-  }, []);
 
   const handleEmailPreferencesSave = async () => {
     if (!creator?.name) {
       console.error('Creator name not found');
-      setSaveSuccess(false);
+      toast({
+        type: 'error',
+        heading: 'Unable to save settings',
+        description: 'Please try again later',
+        autoClose: true,
+      });
       return;
     }
     try {
       const authToken = await getAccessToken();
       if (!authToken) {
         console.error('Not authenticated');
-        setSaveSuccess(false);
+        toast({
+          type: 'error',
+          heading: 'Unable to save settings',
+          description: 'Please try again later',
+          autoClose: true,
+        });
         return;
       }
 
@@ -63,10 +69,19 @@ export default function ProfilePage() {
       });
 
       await editCreatorProfile(creator.name, { receiveEmails }, authToken);
-      setSaveSuccess(true);
+      toast({
+        type: 'success',
+        heading: 'Settings saved!',
+        autoClose: true,
+      });
     } catch (error) {
       console.error('Failed to save email:', error);
-      setSaveSuccess(false);
+      toast({
+        type: 'error',
+        heading: 'Unable to save settings',
+        description: 'Please try again later',
+        autoClose: true,
+      });
     }
   };
 
@@ -256,25 +271,6 @@ export default function ProfilePage() {
         confirmButtonText="CONFIRM"
         cancelButtonText="CANCEL"
       />
-
-      {/* Alerts */}
-      {saveSuccess && (
-        <Toast
-          heading="Settings saved!"
-          type="success"
-          autoClose
-          onClose={handleAlertClose}
-        />
-      )}
-      {saveSuccess === false && (
-        <Toast
-          heading="Unable to save settings"
-          type="error"
-          description="Please try again later"
-          autoClose
-          onClose={handleAlertClose}
-        />
-      )}
     </>
   );
 }

--- a/apps/main-landing/src/app/creators/app/profile/page.tsx
+++ b/apps/main-landing/src/app/creators/app/profile/page.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@idriss-xyz/ui/icon';
 import Image from 'next/image';
 import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
 import { Checkbox } from '@idriss-xyz/ui/checkbox';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 
 import { IDRISS_SCENE_STREAM_4, backgroundLines2 } from '@/assets';
 import { useAuth } from '@/app/creators/context/auth-context';
@@ -259,7 +259,7 @@ export default function ProfilePage() {
 
       {/* Alerts */}
       {saveSuccess && (
-        <Alert
+        <Toast
           heading="Settings saved!"
           type="success"
           autoClose
@@ -267,7 +267,7 @@ export default function ProfilePage() {
         />
       )}
       {saveSuccess === false && (
-        <Alert
+        <Toast
           heading="Unable to save settings"
           type="error"
           description="Please try again later"

--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -6,7 +6,6 @@ import {
   DEFAULT_ALLOWED_CHAINS_IDS,
   TokenSymbol,
 } from '@idriss-xyz/constants';
-import { Toast } from '@idriss-xyz/ui/toast';
 import { Button } from '@idriss-xyz/ui/button';
 import { Card } from '@idriss-xyz/ui/card';
 import { Form } from '@idriss-xyz/ui/form';
@@ -27,6 +26,7 @@ import {
   FormFieldWrapper,
   SectionHeader,
 } from '@/app/creators/components/layout';
+import { useToast } from '@/app/creators/context/toast-context';
 
 import SkeletonSetup from '../loading';
 
@@ -99,8 +99,8 @@ const IconsRow = ({ icons }: { icons: IconName[] }) => {
 // ts-unused-exports:disable-next-line
 export default function PaymentMethods() {
   const { creator, creatorLoading } = useAuth();
+  const { toast } = useToast();
 
-  const [saveSuccess, setSaveSuccess] = useState<boolean | null>(null);
   const [toggleCrypto, setToggleCrypto] = useState(true);
 
   const formMethods = useForm<FormPayload>({
@@ -198,9 +198,6 @@ export default function PaymentMethods() {
     });
   }, []);
 
-  const handleAlertClose = useCallback(() => {
-    setSaveSuccess(null);
-  }, []);
 
   const onChangeChainId = useCallback(() => {
     formMethods.setValue(
@@ -217,12 +214,22 @@ export default function PaymentMethods() {
     try {
       const authToken = await getAccessToken();
       if (!authToken) {
-        setSaveSuccess(false);
+        toast({
+          type: 'error',
+          heading: 'Unable to save settings',
+          description: 'Please try again later',
+          autoClose: true,
+        });
         console.error('Could not get auth token.');
         return;
       }
       if (!creator?.name) {
-        setSaveSuccess(false);
+        toast({
+          type: 'error',
+          heading: 'Unable to save settings',
+          description: 'Please try again later',
+          autoClose: true,
+        });
         console.error('Creator not initialized');
         return;
       }
@@ -238,9 +245,28 @@ export default function PaymentMethods() {
         authToken,
       );
 
-      setSaveSuccess(editSuccess);
+      if (editSuccess) {
+        toast({
+          type: 'success',
+          heading: 'Settings saved!',
+          autoClose: true,
+        });
+      } else {
+        toast({
+          type: 'error',
+          heading: 'Unable to save settings',
+          description: 'Please try again later',
+          autoClose: true,
+        });
+      }
     } catch (error) {
       console.error('Error saving profile:', error);
+      toast({
+        type: 'error',
+        heading: 'Unable to save settings',
+        description: 'Please try again later',
+        autoClose: true,
+      });
     }
   };
 
@@ -382,25 +408,6 @@ export default function PaymentMethods() {
           </FormFieldWrapper>
         </Form>
       </div>
-
-      {/* Alerts section */}
-      {saveSuccess && (
-        <Toast
-          heading="Settings saved!"
-          type="success"
-          autoClose
-          onClose={handleAlertClose}
-        />
-      )}
-      {saveSuccess === false && (
-        <Toast
-          heading="Unable to save settings"
-          type="error"
-          description="Please try again later"
-          autoClose
-          onClose={handleAlertClose}
-        />
-      )}
     </Card>
   );
 }

--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -6,7 +6,7 @@ import {
   DEFAULT_ALLOWED_CHAINS_IDS,
   TokenSymbol,
 } from '@idriss-xyz/constants';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 import { Button } from '@idriss-xyz/ui/button';
 import { Card } from '@idriss-xyz/ui/card';
 import { Form } from '@idriss-xyz/ui/form';
@@ -385,7 +385,7 @@ export default function PaymentMethods() {
 
       {/* Alerts section */}
       {saveSuccess && (
-        <Alert
+        <Toast
           heading="Settings saved!"
           type="success"
           autoClose
@@ -393,7 +393,7 @@ export default function PaymentMethods() {
         />
       )}
       {saveSuccess === false && (
-        <Alert
+        <Toast
           heading="Unable to save settings"
           type="error"
           description="Please try again later"

--- a/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/payment-methods/page.tsx
@@ -198,7 +198,6 @@ export default function PaymentMethods() {
     });
   }, []);
 
-
   const onChangeChainId = useCallback(() => {
     formMethods.setValue(
       'tokensSymbols',

--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -4,7 +4,7 @@ import { Button } from '@idriss-xyz/ui/button';
 import { Card } from '@idriss-xyz/ui/card';
 import { Form } from '@idriss-xyz/ui/form';
 import { Toggle } from '@idriss-xyz/ui/toggle';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 import { getAccessToken } from '@privy-io/react-auth';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -677,7 +677,7 @@ Do not share it with anyone or show it on stream."
 
       {/* Alerts */}
       {testDonationSuccess && (
-        <Alert
+        <Toast
           heading="Test alert sent successfully!"
           type="success"
           description="Check your stream preview to see it"
@@ -687,7 +687,7 @@ Do not share it with anyone or show it on stream."
         />
       )}
       {testDonationSuccess === false && (
-        <Alert
+        <Toast
           heading="Unable to send test alert"
           type="error"
           description="Check your streaming software and verify the link"
@@ -697,7 +697,7 @@ Do not share it with anyone or show it on stream."
         />
       )}
       {saveSuccess && (
-        <Alert
+        <Toast
           heading="Settings saved!"
           type="success"
           autoClose
@@ -705,7 +705,7 @@ Do not share it with anyone or show it on stream."
         />
       )}
       {showRefreshAlert && (
-        <Alert
+        <Toast
           heading="Refresh the browser source in your streaming software"
           type="success"
           description="Keeps your donation alert setup up to date"
@@ -715,7 +715,7 @@ Do not share it with anyone or show it on stream."
         />
       )}
       {saveSuccess === false && (
-        <Alert
+        <Toast
           heading="Unable to save settings"
           type="error"
           description="Please try again later"
@@ -724,7 +724,7 @@ Do not share it with anyone or show it on stream."
         />
       )}
       {isDirtyNonToggles && (
-        <Alert
+        <Toast
           heading="You have unsaved changes"
           type="error"
           description="Don't forget to save when you are done"

--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -260,16 +260,6 @@ export default function StreamAlerts() {
           autoClose: true,
         });
 
-        // Show refresh alert after 3 seconds
-        setTimeout(() => {
-          toast({
-            type: 'success',
-            heading: 'Refresh the browser source in your streaming software',
-            description: 'Keeps your donation alert setup up to date',
-            iconName: 'RefreshCw',
-            autoClose: true,
-          });
-        }, 3000);
       } else {
         toast({
           type: 'error',
@@ -696,7 +686,7 @@ export default function StreamAlerts() {
             )}
           </FormFieldWrapper>
 
-          {alertEnabled && (
+          {alertEnabled && isDirtyNonToggles && (
             <Button
               size="medium"
               intent="primary"

--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -365,6 +365,7 @@ export default function StreamAlerts() {
         heading: 'You have unsaved changes',
         description: 'Don´t forget to save when you are done',
         iconName: 'RefreshCw',
+        closable: false,
       });
     }
   }, [isDirtyNonToggles])

--- a/apps/main-landing/src/app/creators/components/copy-input/copy-input.tsx
+++ b/apps/main-landing/src/app/creators/components/copy-input/copy-input.tsx
@@ -1,6 +1,6 @@
 import { classes } from '@idriss-xyz/ui/utils';
 import { Icon, type IconName } from '@idriss-xyz/ui/icon';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
 
@@ -61,10 +61,10 @@ export function CopyInput({
         )}
       </div>
 
-      {/* Copy Alert */}
+      {/* Copy Toast */}
       {copied && (
         <div className="fixed bottom-[3vh] left-1/2 z-50">
-          <Alert
+          <Toast
             type="success"
             heading="Your link has been copied!"
             autoClose

--- a/apps/main-landing/src/app/creators/components/copy-input/copy-input.tsx
+++ b/apps/main-landing/src/app/creators/components/copy-input/copy-input.tsx
@@ -1,8 +1,8 @@
 import { classes } from '@idriss-xyz/ui/utils';
 import { Icon, type IconName } from '@idriss-xyz/ui/icon';
-import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
+import { useToast } from '../../context/toast-context';
 
 type CopyInputProperties = {
   value: string;
@@ -22,9 +22,15 @@ export function CopyInput({
   wasCopied,
 }: CopyInputProperties) {
   const { copied, copy } = useCopyToClipboard();
+  const { toast } = useToast();
 
   const doCopy = () => {
     void copy(value);
+    toast({
+      type: 'success',
+      heading: 'Your link has been copied!',
+      autoClose: true,
+    });
   };
 
   const handleIconClick = () => {
@@ -60,17 +66,6 @@ export function CopyInput({
           <Icon name={iconName ?? 'Copy'} size={16} />
         )}
       </div>
-
-      {/* Copy Toast */}
-      {copied && (
-        <div className="fixed bottom-[3vh] left-1/2 z-50">
-          <Toast
-            type="success"
-            heading="Your link has been copied!"
-            autoClose
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/main-landing/src/app/creators/components/leaderboard/leaderboard.tsx
+++ b/apps/main-landing/src/app/creators/components/leaderboard/leaderboard.tsx
@@ -14,12 +14,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@idriss-xyz/ui/tooltip';
-import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '@/app/creators/hooks/use-copy-to-clipboard';
 import { IDRISS_SCENE_STREAM_2 } from '@/assets';
 
 import { useAuth } from '../../context/auth-context';
+import { useToast } from '../../context/toast-context';
 import { WidgetVariants } from '../../../../../../twitch-extension/src/app/types';
 import { DonateContentValues } from '../../donate/types';
 import { useTimeAgo } from '../../donate/hooks/use-time-ago';
@@ -109,6 +109,7 @@ export const Leaderboard = ({
 }: Properties) => {
   const { copied, copy } = useCopyToClipboard();
   const { creator } = useAuth();
+  const { toast } = useToast();
   const columns: ColumnDefinition<LeaderboardStats>[] = [
     {
       id: 'rank',
@@ -171,6 +172,11 @@ export const Leaderboard = ({
   const handleCopyLink = () => {
     if (creator?.donationUrl) {
       void copy(creator.donationUrl);
+      toast({
+        type: 'success',
+        heading: 'Your link has been copied!',
+        autoClose: true,
+      });
     }
   };
 
@@ -499,15 +505,6 @@ export const Leaderboard = ({
           >
             See full donation history
           </Link>
-        </div>
-      )}
-      {copied && (
-        <div className="fixed bottom-[3vh] left-1/2 z-50 -translate-x-1/2">
-          <Toast
-            type="success"
-            heading="Your link has been copied!"
-            autoClose
-          />
         </div>
       )}
     </div>

--- a/apps/main-landing/src/app/creators/components/leaderboard/leaderboard.tsx
+++ b/apps/main-landing/src/app/creators/components/leaderboard/leaderboard.tsx
@@ -14,7 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@idriss-xyz/ui/tooltip';
-import { Alert } from '@idriss-xyz/ui/alert';
+import { Toast } from '@idriss-xyz/ui/toast';
 
 import { useCopyToClipboard } from '@/app/creators/hooks/use-copy-to-clipboard';
 import { IDRISS_SCENE_STREAM_2 } from '@/assets';
@@ -503,7 +503,7 @@ export const Leaderboard = ({
       )}
       {copied && (
         <div className="fixed bottom-[3vh] left-1/2 z-50 -translate-x-1/2">
-          <Alert
+          <Toast
             type="success"
             heading="Your link has been copied!"
             autoClose

--- a/apps/main-landing/src/app/creators/context/toast-context.tsx
+++ b/apps/main-landing/src/app/creators/context/toast-context.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useCallback,
+} from 'react';
 import { Toast } from '@idriss-xyz/ui/toast';
 import { IconName } from '@idriss-xyz/ui/icon';
 
@@ -17,7 +23,8 @@ interface ToastData {
 }
 
 interface ToastContextValue {
-  toast: (options: Omit<ToastData, 'id'>) => void;
+  toast: (options: Omit<ToastData, 'id'>) => string;
+  removeToast: (id: string) => void;
 }
 
 const ToastContext = createContext<ToastContextValue | undefined>(undefined);
@@ -30,45 +37,56 @@ export const useToast = () => {
   return context;
 };
 
-interface ToastProviderProps {
+interface ToastProviderProperties {
   children: ReactNode;
 }
 
-export const ToastProvider = ({ children }: ToastProviderProps) => {
+export const ToastProvider = ({ children }: ToastProviderProperties) => {
   const [toasts, setToasts] = useState<ToastData[]>([]);
 
   const toast = useCallback((options: Omit<ToastData, 'id'>) => {
-    const id = Math.random().toString(36).substring(2, 9);
+    const id = Math.random().toString(36).slice(2, 9);
     const newToast: ToastData = {
       ...options,
       id,
     };
 
-    setToasts(prev => [...prev, newToast]);
+    setToasts((previous) => {
+      return [...previous, newToast];
+    });
+    return id;
   }, []);
 
   const removeToast = useCallback((id: string) => {
-    setToasts(prev => prev.filter(toast => toast.id !== id));
+    setToasts((previous) => {
+      return previous.filter((toast) => {
+        return toast.id !== id;
+      });
+    });
   }, []);
 
   return (
-    <ToastContext.Provider value={{ toast }}>
+    <ToastContext.Provider value={{ toast, removeToast }}>
       {children}
 
       {/* Toast Container */}
-      <div className="fixed bottom-0 left-1/2 z-alert gap-3 flex flex-col-reverse py-3">
-        {toasts.map((toastData) => (
-          <Toast
-            key={toastData.id}
-            type={toastData.type}
-            heading={toastData.heading}
-            description={toastData.description}
-            iconName={toastData.iconName}
-            autoClose={toastData.autoClose}
-            actionButtons={toastData.actionButtons}
-            onClose={() => removeToast(toastData.id)}
-          />
-        ))}
+      <div className="fixed bottom-0 left-1/2 z-alert flex flex-col-reverse gap-3 py-3">
+        {toasts.map((toastData) => {
+          return (
+            <Toast
+              key={toastData.id}
+              type={toastData.type}
+              heading={toastData.heading}
+              description={toastData.description}
+              iconName={toastData.iconName}
+              autoClose={toastData.autoClose}
+              actionButtons={toastData.actionButtons}
+              onClose={() => {
+                return removeToast(toastData.id);
+              }}
+            />
+          );
+        })}
       </div>
     </ToastContext.Provider>
   );

--- a/apps/main-landing/src/app/creators/context/toast-context.tsx
+++ b/apps/main-landing/src/app/creators/context/toast-context.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import { Toast } from '@idriss-xyz/ui/toast';
+import { IconName } from '@idriss-xyz/ui/icon';
+
+type ToastType = 'default' | 'success' | 'error';
+
+interface ToastData {
+  id: string;
+  type: ToastType;
+  heading: string;
+  description?: string;
+  iconName?: IconName;
+  autoClose?: boolean;
+  actionButtons?: (close: () => void) => ReactNode;
+}
+
+interface ToastContextValue {
+  toast: (options: Omit<ToastData, 'id'>) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};
+
+interface ToastProviderProps {
+  children: ReactNode;
+}
+
+export const ToastProvider = ({ children }: ToastProviderProps) => {
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  const toast = useCallback((options: Omit<ToastData, 'id'>) => {
+    const id = Math.random().toString(36).substring(2, 9);
+    const newToast: ToastData = {
+      ...options,
+      id,
+    };
+
+    setToasts(prev => [...prev, newToast]);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+
+      {/* Toast Container */}
+      <div className="fixed bottom-[3vh] left-1/2 z-50 flex -translate-x-1/2 flex-col-reverse gap-3">
+        {toasts.map((toastData) => (
+          <Toast
+            key={toastData.id}
+            type={toastData.type}
+            heading={toastData.heading}
+            description={toastData.description}
+            iconName={toastData.iconName}
+            autoClose={toastData.autoClose}
+            actionButtons={toastData.actionButtons}
+            onClose={() => removeToast(toastData.id)}
+          />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};

--- a/apps/main-landing/src/app/creators/context/toast-context.tsx
+++ b/apps/main-landing/src/app/creators/context/toast-context.tsx
@@ -55,7 +55,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
       {children}
 
       {/* Toast Container */}
-      <div className="fixed bottom-[3vh] left-1/2 z-50 flex -translate-x-1/2 flex-col-reverse gap-3">
+      <div className="fixed bottom-0 left-1/2 z-alert gap-3 flex flex-col-reverse py-3">
         {toasts.map((toastData) => (
           <Toast
             key={toastData.id}

--- a/apps/main-landing/src/app/creators/context/toast-context.tsx
+++ b/apps/main-landing/src/app/creators/context/toast-context.tsx
@@ -12,6 +12,7 @@ interface ToastData {
   description?: string;
   iconName?: IconName;
   autoClose?: boolean;
+  closable?: boolean;
   actionButtons?: (close: () => void) => ReactNode;
 }
 

--- a/apps/main-landing/src/app/creators/providers.tsx
+++ b/apps/main-landing/src/app/creators/providers.tsx
@@ -6,6 +6,7 @@ import { PrivyProvider } from '@privy-io/react-auth';
 import { TooltipProvider } from '@idriss-xyz/ui/tooltip';
 
 import { QueryProvider } from '@/providers';
+
 import { ToastProvider } from './context/toast-context';
 
 type Properties = {

--- a/apps/main-landing/src/app/creators/providers.tsx
+++ b/apps/main-landing/src/app/creators/providers.tsx
@@ -6,6 +6,7 @@ import { PrivyProvider } from '@privy-io/react-auth';
 import { TooltipProvider } from '@idriss-xyz/ui/tooltip';
 
 import { QueryProvider } from '@/providers';
+import { ToastProvider } from './context/toast-context';
 
 type Properties = {
   children: ReactNode;
@@ -30,26 +31,28 @@ export const Providers = ({ children }: Properties) => {
       <WithPortal>
         <NiceModal.Provider>
           <TooltipProvider delayDuration={400}>
-            <PrivyProvider
-              appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID ?? ''}
-              config={{
-                appearance: {
-                  theme: 'light',
-                  accentColor: '#000000',
-                  showWalletLoginFirst: true,
-                },
-                // This handles the custom Twitch login flow
-                customAuth: {
-                  getCustomAccessToken: getCustomAuthToken,
-                  isLoading: loadingToken,
-                },
-                embeddedWallets: {
-                  createOnLogin: 'users-without-wallets',
-                },
-              }}
-            >
-              {children}
-            </PrivyProvider>
+            <ToastProvider>
+              <PrivyProvider
+                appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID ?? ''}
+                config={{
+                  appearance: {
+                    theme: 'light',
+                    accentColor: '#000000',
+                    showWalletLoginFirst: true,
+                  },
+                  // This handles the custom Twitch login flow
+                  customAuth: {
+                    getCustomAccessToken: getCustomAuthToken,
+                    isLoading: loadingToken,
+                  },
+                  embeddedWallets: {
+                    createOnLogin: 'users-without-wallets',
+                  },
+                }}
+              >
+                {children}
+              </PrivyProvider>
+            </ToastProvider>
           </TooltipProvider>
         </NiceModal.Provider>
       </WithPortal>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "./geo-conditional-button": "./src/components/geo-conditional-button/index.ts",
     "./badge": "./src/components/badge/index.ts",
     "./blocked-button": "./src/components/blocked-button/index.ts",
-    "./alert": "./src/components/alert/index.ts",
+    "./toast": "./src/components/toast/index.ts",
     "./card": "./src/components/card/index.ts",
     "./charts": "./src/components/charts/index.ts",
     "./divider": "./src/components/divider/index.ts",

--- a/packages/ui/src/components/alert/index.ts
+++ b/packages/ui/src/components/alert/index.ts
@@ -1,1 +1,0 @@
-export { Alert } from './alert';

--- a/packages/ui/src/components/toast/index.ts
+++ b/packages/ui/src/components/toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast } from './toast';

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -26,6 +26,7 @@ type Properties = {
 } & ToastVariants &
   HTMLProps<HTMLSpanElement>;
 
+// Meant to be used within Toast context as in creators app
 export const Toast = forwardRef(
   (
     {

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -18,6 +18,7 @@ type Properties = {
   heading: string;
   description?: string;
   autoClose?: boolean;
+  closable?: boolean;
   show?: boolean;
   iconName?: IconName;
   setShow?: (show: boolean) => void;
@@ -35,6 +36,7 @@ export const Toast = forwardRef(
       heading,
       description,
       autoClose,
+      closable,
       iconName,
       onClose,
       actionButtons,
@@ -75,7 +77,7 @@ export const Toast = forwardRef(
         </span>
 
         <div
-          className={`grid ${autoClose ? 'grid-cols-[1fr]' : 'grid-cols-[1fr,32px]'}`}
+          className={`grid ${autoClose || !closable ? 'grid-cols-[1fr]' : 'grid-cols-[1fr,32px]'}`}
         >
           <div className="flex flex-col gap-y-1">
             <p className="flex h-full items-center text-label3 text-neutral-900">
@@ -91,7 +93,7 @@ export const Toast = forwardRef(
               </div>
             )}
           </div>
-          {!autoClose && (
+          {!autoClose && closable && (
             <IconButton
               size="small"
               iconName="X"

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -12,7 +12,7 @@ import { classes } from '../../utils';
 import { Icon, IconName } from '../icon';
 import { IconButton } from '../icon-button';
 
-import { alert, AlertVariants, icon, iconClass } from './variants';
+import { toast, ToastVariants, icon, iconClass } from './variants';
 
 type Properties = {
   heading: string;
@@ -23,10 +23,10 @@ type Properties = {
   setShow?: (show: boolean) => void;
   onClose?: () => void;
   actionButtons?: (close: () => void) => ReactNode;
-} & AlertVariants &
+} & ToastVariants &
   HTMLProps<HTMLSpanElement>;
 
-export const Alert = forwardRef(
+export const Toast = forwardRef(
   (
     {
       type,
@@ -43,7 +43,7 @@ export const Alert = forwardRef(
   ) => {
     const [isVisible, setIsVisible] = useState(true);
 
-    const variantClassName = classes(alert({ type }), className);
+    const variantClassName = classes(toast({ type }), className);
     const iconClassName = iconClass({ type });
 
     const Component = 'span';
@@ -105,4 +105,4 @@ export const Alert = forwardRef(
   },
 );
 
-Alert.displayName = 'Alert';
+Toast.displayName = 'Toast';

--- a/packages/ui/src/components/toast/variants.ts
+++ b/packages/ui/src/components/toast/variants.ts
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority';
 
 import { IconName } from '../icon';
 
-export const alert = cva(
+export const toast = cva(
   'fixed bottom-[3vh] left-1/2 z-alert grid max-h-[500px] grid-cols-[40px,1fr] items-center gap-x-4 rounded-xl border border-neutral-300 bg-white p-4 shadow-sm',
   {
     variants: {
@@ -32,6 +32,6 @@ export const iconClass = cva('rounded-full p-2.5', {
   },
 });
 
-export type AlertVariants = FullyRequired<{
+export type ToastVariants = FullyRequired<{
   type: 'default' | 'success' | 'error';
 }>;

--- a/packages/ui/src/components/toast/variants.ts
+++ b/packages/ui/src/components/toast/variants.ts
@@ -4,7 +4,7 @@ import { cva } from 'class-variance-authority';
 import { IconName } from '../icon';
 
 export const toast = cva(
-  'w-fit grid max-h-[500px] grid-cols-[40px,1fr] items-center gap-x-4 rounded-xl border border-neutral-300 bg-white p-4 shadow-sm',
+  'grid max-h-[500px] w-fit grid-cols-[40px,1fr] items-center gap-x-4 rounded-xl border border-neutral-300 bg-white p-4 shadow-sm',
   {
     variants: {
       type: {

--- a/packages/ui/src/components/toast/variants.ts
+++ b/packages/ui/src/components/toast/variants.ts
@@ -4,7 +4,7 @@ import { cva } from 'class-variance-authority';
 import { IconName } from '../icon';
 
 export const toast = cva(
-  'fixed bottom-[3vh] left-1/2 z-alert grid max-h-[500px] grid-cols-[40px,1fr] items-center gap-x-4 rounded-xl border border-neutral-300 bg-white p-4 shadow-sm',
+  'w-fit grid max-h-[500px] grid-cols-[40px,1fr] items-center gap-x-4 rounded-xl border border-neutral-300 bg-white p-4 shadow-sm',
   {
     variants: {
       type: {


### PR DESCRIPTION
## Overview
Fixes these issues with toasts:
"unsaved changes" alert should be persistent and switch to the "settings saved" once "save button" is hit
"save" button should show up only on changes to the internal config (everything except toggles)
remove the refresh toast from the sequence (we shipped the websocked update so it's not needed anymore, I suggest we comment it out and keep it in code in case it's needed in the future)

- Alert was renamed to Toast
- A refactor was needed to centralize logic into a Toast context view so that toasts appear one after the other on top.