### PR TITLE
fix: Add www STATIC_ORIGINS (solves websocket connect cors error)

### DIFF
--- a/packages/constants/src/links.ts
+++ b/packages/constants/src/links.ts
@@ -2,7 +2,9 @@ export const MAIN_LANDING_LINK = 'https://www.idriss.xyz';
 export const VAULT_LINK = 'https://www.idriss.xyz/vault';
 export const STATIC_ORIGINS = [
   'https://idriss.xyz',
+  'https://www.idriss.xyz',
   'https://main-landing-staging.up.railway.app',
+  'https://www.main-landing-staging.up.railway.app',
   'http://localhost:3000',
 ];
 


### PR DESCRIPTION
## Overview
Solves the donation overlay websocket connection errors not allowing test donation alerts (or any alert for that matter) to pop up on screen. 