### PR TITLE
fix: Don't throw error when wallet linked to current donor on donate page

### DIFF
--- a/apps/creator-api/routes/siwe.ts
+++ b/apps/creator-api/routes/siwe.ts
@@ -160,19 +160,12 @@ router.get(
 
     const creatorAddressRepository =
       AppDataSource.getRepository(CreatorAddress);
-    console.log('Checking if address is linked for ', address);
-    console.log('Checking if address is linked for ', req.user.id);
-    const creator = await creatorAddressRepository.findOne({
-      where: { address },
-      select: ['id'],
-    });
-    console.log('Found creator', creator);
-    const linked = !!(await creatorAddressRepository.findOne({
-      where: { address },
-      select: ['id'],
-    }));
 
-    res.json({ linked });
+    const linkedCreator = await creatorAddressRepository.findOne({
+      where: { address },
+    });
+
+    res.json({ linkedTo: linkedCreator?.creator.name });
     return;
   },
 );

--- a/apps/main-landing/src/app/creators/donate/components/donate-form/donate-form.tsx
+++ b/apps/main-landing/src/app/creators/donate/components/donate-form/donate-form.tsx
@@ -66,7 +66,7 @@ const baseClassName =
 export const DonateForm = forwardRef<HTMLDivElement, Properties>(
   ({ className, creatorInfo }, reference) => {
     const { isConnected } = useAccount();
-    const { setCreator } = useAuth();
+    const { donor, setCreator } = useAuth();
     const { data: walletClient } = useWalletClient();
     const { connectModalOpen, openConnectModal } = useConnectModal();
     const [selectedTokenSymbol, setSelectedTokenSymbol] =
@@ -194,11 +194,15 @@ export const DonateForm = forwardRef<HTMLDivElement, Properties>(
       const linkedResult = await fetch(`${CREATOR_API_URL}/siwe/linked?${qs}`, {
         headers: { Authorization: `Bearer ${authToken}` },
       });
-      const { linked } = await linkedResult.json();
-      if (linked) {
+      const { linkedTo } = await linkedResult.json();
+      // Wallet is already linked to another (not donor's) public account
+      if (linkedTo && linkedTo !== donor?.name) {
         throw new Error('This wallet is already linked to a public account.');
       }
+      // Wallet is already linked to the donor account
+      else if (linkedTo) return;
 
+      // Wallet is not linked to any account, link to current
       // 2) nonce
       const nonceResult = await fetch(`${CREATOR_API_URL}/siwe/nonce`, {
         headers: { Authorization: `Bearer ${authToken}` },


### PR DESCRIPTION
## Overview
Solves an issue where donating with a wallet (even tho it was linked to the current connected donor on donate page) was showing error:
<img width="836" height="192" alt="image" src="https://github.com/user-attachments/assets/16f95bd7-e16d-4409-94a7-080adb103f7f" />
