### PR TITLE
make it so that empty messages dont result in `yy` sound but stay empty

### DIFF
--- a/apps/creator-api/utils/calculate-balances.ts
+++ b/apps/creator-api/utils/calculate-balances.ts
@@ -291,7 +291,7 @@ export async function calculateNftBalances(
           contract: nft.contract,
           collection: meta.name,
           tokenId,
-          balance: type === 'erc721' ? '1' : '0',
+          balance: '1', // defaulting to 1 as opensea only returns owned nfts (without exact balance)
           type,
           image: dbRow?.imageUrl ?? undefined,
           collectionImage: meta.image,

--- a/apps/main-landing/src/app/creators/donation-overlay/hooks/use-donation-notification.ts
+++ b/apps/main-landing/src/app/creators/donation-overlay/hooks/use-donation-notification.ts
@@ -137,7 +137,7 @@ export const useDonationNotification = (
             );
             ttsAudioForPlayback = ttsAudioElementReference.current;
           } else {
-            const ttsStream = await getTextToSpeech(message, voiceId);
+            const ttsStream = await getTextToSpeech(message.trim(), voiceId);
             if (ttsStream) {
               ttsAudioElementReference.current =
                 await toAudioElement(ttsStream);

--- a/apps/main-landing/src/app/creators/donation-overlay/utils.ts
+++ b/apps/main-landing/src/app/creators/donation-overlay/utils.ts
@@ -79,6 +79,7 @@ export async function calculateDollar(
 }
 
 export const getTextToSpeech = async (text: string, voiceId?: string) => {
+  if (text === '') return null;
   try {
     const response = await fetch(
       `${CREATOR_API_URL}/text-to-speech/${voiceId}`,


### PR DESCRIPTION
1) messages are prefixed with ` ` to distinguish donations in indexers. this results in empty sound translation with eleven labs. -> now returning null in case of empty message
2) default to balance 1 instead of 0 for erc1155