### PR TITLE
fix: Hide privy popup on register from UI

### DIFF
--- a/apps/main-landing/src/app/globals.css
+++ b/apps/main-landing/src/app/globals.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Hide Privy "All set!" modal */
+[data-privy-modal] h3:has(> :where(:not(script)):where(:not(style)):where(:not(template)):where(:not(:empty)):contains("All set!")),
+[data-privy-modal] h3:has(> :where(:not(script)):where(:not(style)):where(:not(template)):where(:not(:empty)):contains("Welcome")),
+[data-privy-modal] h3:contains("All set!"),
+[data-privy-modal] h3:contains("Welcome") {
+  display: none !important;
+}


### PR DESCRIPTION
## Overview
Hides privy popup on signup from creators landing and from donate page (pending test on staging)
<img width="527" height="506" alt="image" src="https://github.com/user-attachments/assets/b5880234-7bc2-4dd0-92e8-1c3812ce60b0" />

## How it is solved
Added css overrides with `display:none` after checking the minified version of the library privy/react-auth and finding the modal headers "All set!" and "Welcome (to IDRISS Creators)" 